### PR TITLE
[BD-6] Mark oep-18 in openedx.yaml

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -15,6 +15,7 @@ oeps:
     oep-5:
         state: False
         reason: Doesn't require any services to be started
+    oep-18: True
     oep-30:
         applicable: False
 openedx-release:

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/openedx.yaml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/openedx.yaml
@@ -16,6 +16,7 @@ oeps:
     oep-5:
         state: False
         reason: TODO - Implement for this application if appropriate
+    oep-18: True
     oep-30:
         state: True
 openedx-release:

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -93,8 +93,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
 )


### PR DESCRIPTION
This PR:

Marks ths repo as oep-18 compliant and mark repos created with this templates as oep-18 compliants.

Removes python 3.6 and python 3.7 from default classifiers.

CC: @jinder1s 