### PR TITLE
Add doc publishing instructions

### DIFF
--- a/cookiecutter-django-app/tests/test_bake_project.py
+++ b/cookiecutter-django-app/tests/test_bake_project.py
@@ -119,7 +119,7 @@ def test_readme(options_baked, custom_template):
     readme_file = Path('README.rst')
     readme_lines = [x.strip() for x in readme_file.open()]
     assert "cookie_repo" == readme_lines[0]
-    assert 'The full documentation is at https://cookie_repo.readthedocs.org.' in readme_lines
+    assert ':target: https://pypi.python.org/pypi/cookie_repo/' in readme_lines
     try:
         sh.python("setup.py", 'check', restructuredtext=True, strict=True)
     except sh.ErrorReturnCode as exc:

--- a/cookiecutter-django-ida/tests/test_ida.py
+++ b/cookiecutter-django-ida/tests/test_ida.py
@@ -110,7 +110,7 @@ def test_readme(options_baked, custom_template):
     readme_file = Path('README.rst')
     readme_lines = [x.strip() for x in readme_file.open()]
     assert "cookie_repo" == readme_lines[0]
-    assert 'The full documentation is at https://cookie_repo.readthedocs.org.' in readme_lines
+    assert ':target: https://pypi.python.org/pypi/cookie_repo/' in readme_lines
     try:
         sh.python("setup.py", 'check', restructuredtext=True, strict=True)
     except sh.ErrorReturnCode as exc:

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -21,7 +21,7 @@ to understand the code in more detail.
 Documentation
 -------------
 
-(TODO: `Set up documentation <https://openedx.atlassian.net/wiki/spaces/DOC/pages/21627535/Publish+Documentation+on+Read+the+Docs`_)
+(TODO: `Set up documentation <https://openedx.atlassian.net/wiki/spaces/DOC/pages/21627535/Publish+Documentation+on+Read+the+Docs>`_)
 
 License
 -------

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -23,6 +23,8 @@ Documentation
 
 The full documentation is at https://{{ cookiecutter.repo_name }}.readthedocs.org.
 
+(Doc publishing instructions: https://openedx.atlassian.net/wiki/spaces/DOC/pages/21627535/Publish+Documentation+on+Read+the+Docs)
+
 License
 -------
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -21,9 +21,7 @@ to understand the code in more detail.
 Documentation
 -------------
 
-The full documentation is at https://{{ cookiecutter.repo_name }}.readthedocs.org.
-
-(Doc publishing instructions: https://openedx.atlassian.net/wiki/spaces/DOC/pages/21627535/Publish+Documentation+on+Read+the+Docs)
+(TODO: `Set up documentation <https://openedx.atlassian.net/wiki/spaces/DOC/pages/21627535/Publish+Documentation+on+Read+the+Docs`_)
 
 License
 -------


### PR DESCRIPTION
**Description:**

The generated README currently shows a link to a nonexistent ReadTheDocs site.
This adds a link to the setup and publishing instructions in place of a bad link.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
