### PR TITLE
Don't let pytest find tests in virtualenv packages

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/tox.ini
@@ -31,7 +31,7 @@ match-dir = (?!migrations)
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings
 addopts = --cov {{ cookiecutter.app_name }} --cov-report term-missing --cov-report xml
-norecursedirs = .* docs requirements
+norecursedirs = .* docs requirements site-packages
 
 [testenv]
 deps =

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/pytest.ini
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = {{cookiecutter.repo_name}}.settings.test
 addopts = --cov {{cookiecutter.repo_name}} --cov-report term-missing --cov-report xml
-norecursedirs = .* docs requirements
+norecursedirs = .* docs requirements site-packages
 
 # Filter depr warnings coming from packages that we can't control.
 filterwarnings =

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/tox.ini
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/tox.ini
@@ -31,7 +31,7 @@ ignore = D101,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D
 
 [pytest]
 addopts = --cov {{ cookiecutter.sub_dir_name }} --cov-report term-missing --cov-report xml
-norecursedirs = .* docs requirements
+norecursedirs = .* docs requirements site-packages
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ max-line-length = 120
 ignore = D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414
 
 [pytest]
-norecursedirs = .* requirements
+norecursedirs = .* requirements site-packages
 
 [testenv]
 setenv = EDX_COOKIECUTTER_ROOTDIR = {toxinidir}
@@ -25,5 +25,7 @@ commands =
     pytest {posargs}
 
 [testenv:quality]
+whitelist_externals =
+    make
 commands =
     make quality

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ max-line-length = 120
 ignore = D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414
 
 [pytest]
-norecursedirs = .* requirements site-packages
+norecursedirs = .* docs requirements site-packages
 
 [testenv]
 setenv = EDX_COOKIECUTTER_ROOTDIR = {toxinidir}


### PR DESCRIPTION
**Description:**

Don't let pytest find tests in virtualenv packages. This was causing tests to fail locally when running `make test`.

Also, declare `make` external command that tox was complaining about.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
