### PR TITLE
Use secure URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ invitation`_, then join our `community Slack team`_.
 For more information about these options, see the `Getting Help`_ page.
 
 .. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
-.. _community Slack team: http://openedx.slack.com/
+.. _community Slack team: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help
 .. _`file an issue`: https://github.com/edx/edx-cookiecutters/issues
 .. _`tox`: https://tox.readthedocs.io/en/latest/

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/internationalization.rst
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/internationalization.rst
@@ -8,7 +8,7 @@ this choice.
 
 Follow the `internationalization coding guidelines`_ in the edX Developer's Guide when developing new features.
 
-.. _internationalization coding guidelines: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
+.. _internationalization coding guidelines: https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
 
 Updating Translations
 ~~~~~~~~~~~~~~~~~~~~~
@@ -22,7 +22,7 @@ Pushing source translation files to Transifex requires access to the edx-platfor
 Team if you will be pushing translation files. You should also `configure the Transifex client`_ if you have not done so
 already.
 
-.. _configure the Transifex client: http://docs.transifex.com/client/config/
+.. _configure the Transifex client: https://docs.transifex.com/client/config/
 
 The `make` targets listed below can be used to push or pull translations.
 

--- a/cookiecutter-django-ida/README.rst
+++ b/cookiecutter-django-ida/README.rst
@@ -3,7 +3,7 @@ cookiecutter-django-ida
 
 A cookiecutter_ template for edX Django projects.
 
-.. _cookiecutter: http://cookiecutter.readthedocs.org/en/latest/index.html
+.. _cookiecutter: https://cookiecutter.readthedocs.org/en/latest/index.html
 
 **This template produces a Python 3.5 project.**
 
@@ -22,7 +22,7 @@ The necessary configuration is also in place to support:
 * Pylint/Pycodestyle validation
 * Travis CI
 
-.. _Sphinx: http://sphinx-doc.org/
+.. _Sphinx: https://sphinx-doc.org/
 
 Usage
 -----

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/CONTRIBUTING.md
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to contribute
 
 This is an Open edX repo, and we welcome your contributions!
-Please read the [contributing guidelines](http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/process/index.html).
+Please read the [contributing guidelines](https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/process/index.html).
 
 
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/docs/features.rst
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/docs/features.rst
@@ -2,7 +2,7 @@ Feature Toggling
 ================
 All new features/functionality should be released behind a feature gate. This allows us to easily disable features
 in the event that an issue is discovered in production. This project uses the
-`Waffle <http://waffle.readthedocs.org/en/latest/>`_ library for feature gating.
+`Waffle <https://waffle.readthedocs.org/en/latest/>`_ library for feature gating.
 
 Waffle supports three types of feature gates (listed below). We typically use flags and switches since samples are
 random, and not ideal for our needs.
@@ -19,7 +19,7 @@ random, and not ideal for our needs.
 
 
 For information on creating or updating features, refer to the
-`Waffle documentation <http://waffle.readthedocs.org/en/latest/>`_.
+`Waffle documentation <https://waffle.readthedocs.org/en/latest/>`_.
 
 Permanent Feature Rollout
 -------------------------

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/docs/internationalization.rst
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/docs/internationalization.rst
@@ -8,7 +8,7 @@ this choice.
 
 Follow the `internationalization coding guidelines`_ in the edX Developer's Guide when developing new features.
 
-.. _internationalization coding guidelines: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
+.. _internationalization coding guidelines: https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
 
 Updating Translations
 ~~~~~~~~~~~~~~~~~~~~~
@@ -22,7 +22,7 @@ Pushing source translation files to Transifex requires access to the edx-platfor
 Team if you will be pushing translation files. You should also `configure the Transifex client`_ if you have not done so
 already.
 
-.. _configure the Transifex client: http://docs.transifex.com/client/config/
+.. _configure the Transifex client: https://docs.transifex.com/client/config/
 
 The `make` targets listed below can be used to push or pull translations.
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/docker_gunicorn_configuration.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/docker_gunicorn_configuration.py
@@ -1,5 +1,5 @@
 """
-gunicorn configuration file: http://docs.gunicorn.org/en/develop/configure.html
+gunicorn configuration file: https://docs.gunicorn.org/en/develop/configure.html
 """
 import multiprocessing  # pylint: disable=unused-import
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/local.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/local.py
@@ -31,7 +31,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # END EMAIL CONFIGURATION
 
 # TOOLBAR CONFIGURATION
-# See: http://django-debug-toolbar.readthedocs.org/en/latest/installation.html
+# See: https://django-debug-toolbar.readthedocs.org/en/latest/installation.html
 if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
     INSTALLED_APPS += (
         'debug_toolbar',

--- a/cookiecutter-python-library/README.rst
+++ b/cookiecutter-python-library/README.rst
@@ -3,7 +3,7 @@ cookiecutter-python-library
 
 A cookiecutter_ template for edX python projects. For django related cookiecutters, see cookiecutters-django-{ida, app} located in edx-cookiecutters.
 
-.. _cookiecutter: http://cookiecutter.readthedocs.org/en/latest/index.html
+.. _cookiecutter: https://cookiecutter.readthedocs.org/en/latest/index.html
 
 **This template produces a Python 3.5 project.**
 

--- a/cookiecutter-xblock/README.rst
+++ b/cookiecutter-xblock/README.rst
@@ -19,4 +19,4 @@ Your XBlock should now be available at http://localhost:8000
 
 As a next step, you can pick up the XBlock tutorial at the `Customizing Your XBlock`_ section.
 
-.. _Customizing Your XBlock: http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/customize/index.html
+.. _Customizing Your XBlock: https://edx.readthedocs.io/projects/xblock-tutorial/en/latest/customize/index.html

--- a/cookiecutter-xblock/openedx.yaml
+++ b/cookiecutter-xblock/openedx.yaml
@@ -1,5 +1,5 @@
 # This file describes this Open edX repo, as described in OEP-2:
-# http://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html#specification
+# https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html#specification
 
 oeps:
     oep-2: true

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/README.rst
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/README.rst
@@ -18,7 +18,7 @@ Localization (l10n) is adapting a program to local language and cultural habits.
 
 Use the locale directory to provide internationalized strings for your XBlock project.
 For more information on how to enable translations, visit the
-`Open edX XBlock tutorial on Internationalization <http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/edx_platform/edx_lms.html>`_.
+`Open edX XBlock tutorial on Internationalization <https://edx.readthedocs.org/projects/xblock-tutorial/en/latest/edx_platform/edx_lms.html>`_.
 
 This cookiecutter template uses `django-statici18n <https://django-statici18n.readthedocs.io/en/latest/>`_
 to provide translations to static javascript using ``gettext``.

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/settings.py
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/settings.py
@@ -36,7 +36,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 # statici18n
-# http://django-statici18n.readthedocs.io/en/latest/settings.html
+# https://django-statici18n.readthedocs.io/en/latest/settings.html
 
 STATICI18N_DOMAIN = 'text'
 STATICI18N_PACKAGES = (

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/CHANGELOG.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/CHANGELOG.rst
@@ -3,11 +3,11 @@ Change Log
 
 ..
    All enhancements and patches to {{ cookiecutter.sub_dir_name }} will be documented
-   in this file.  It adheres to the structure of http://keepachangelog.com/ ,
+   in this file.  It adheres to the structure of https://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
    
-   This project adheres to Semantic Versioning (http://semver.org/).
+   This project adheres to Semantic Versioning (https://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -62,7 +62,7 @@ invitation`_, then join our `community Slack team`_.
 For more information about these options, see the `Getting Help`_ page.
 
 .. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
-.. _community Slack team: http://openedx.slack.com/
+.. _community Slack team: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help
 
 .. |pypi-badge| image:: https://img.shields.io/pypi/v/{{ cookiecutter.repo_name }}.svg
@@ -73,12 +73,12 @@ For more information about these options, see the `Getting Help`_ page.
     :target: https://travis-ci.org/edx/{{ cookiecutter.repo_name }}
     :alt: Travis
 
-.. |codecov-badge| image:: http://codecov.io/github/edx/{{ cookiecutter.repo_name }}/coverage.svg?branch=master
-    :target: http://codecov.io/github/edx/{{ cookiecutter.repo_name }}?branch=master
+.. |codecov-badge| image:: https://codecov.io/github/edx/{{ cookiecutter.repo_name }}/coverage.svg?branch=master
+    :target: https://codecov.io/github/edx/{{ cookiecutter.repo_name }}?branch=master
     :alt: Codecov
 
 .. |doc-badge| image:: https://readthedocs.org/projects/{{ cookiecutter.repo_name }}/badge/?version=latest
-    :target: http://{{ cookiecutter.repo_name }}.readthedocs.io/en/latest/
+    :target: https://{{ cookiecutter.repo_name }}.readthedocs.io/en/latest/
     :alt: Documentation
 
 .. |pyversions-badge| image:: https://img.shields.io/pypi/pyversions/{{ cookiecutter.repo_name }}.svg

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/Makefile
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/internationalization.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/internationalization.rst
@@ -8,7 +8,7 @@ this choice.
 
 Follow the `internationalization coding guidelines`_ in the edX Developer's Guide when developing new features.
 
-.. _internationalization coding guidelines: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
+.. _internationalization coding guidelines: https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
 
 Updating Translations
 ~~~~~~~~~~~~~~~~~~~~~
@@ -22,7 +22,7 @@ Pushing source translation files to Transifex requires access to the edx-platfor
 Team if you will be pushing translation files. You should also `configure the Transifex client`_ if you have not done so
 already.
 
-.. _configure the Transifex client: http://docs.transifex.com/client/config/
+.. _configure the Transifex client: https://docs.transifex.com/client/config/
 
 The `make` targets listed below can be used to push or pull translations.
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/make.bat
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/make.bat
@@ -67,7 +67,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 


### PR DESCRIPTION
We have a lot of insecure HTTP URLs in repos. These all redirect to HTTPS currently, but run the risk of man in the middle attacks before the redirect occurs.

(I left alone any URLs in license files and generated files.)