### PR TITLE
Simplify local development and cleanup ENV variable use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ help: ## display this help message
 # Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
 PIP_COMPILE = pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
 
+TEMPLATES=$(wildcard cookiecutter-*)
+.PHONY: $(TEMPLATES)
+$(TEMPLATES): ## Create a new repo from the template
+	test -e var/ || mkdir var
+	EDX_COOKIECUTTER_ROOTDIR=$(PWD) cookiecutter $(PWD) --directory $(@) --output-dir var
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -qr requirements/pip-tools.txt

--- a/README.rst
+++ b/README.rst
@@ -42,11 +42,17 @@ If you are updating above cookiecutters, please see docs/decisions/0003-layered-
 Local Debugging of the layered cookiecutters
 --------------------------------------------
 
-To debug locally, set the env variable EDX_COOKIECUTTER_ROOTDIR to the root of the edx-cookiecutters repository. For example, from inside /edx-cookiecutters, use::
+To ensure that the layered cookiecutters pull from your local code,
+instead of Github, run cookiecutter like::
 
-    $ export EDX_COOKIECUTTER_ROOTDIR="/edx-cookiecutters"
+    $ make cookiecutter-<TEMPLATE-NAME>
 
-Without this environment variable, the layered cookiecutters will pull templates from github, which will not have your local changes on them.
+eg::
+
+    $ make cookiecutter-django-app
+    $ make cookiecutter-django-ida
+    $ make cookiecutter-python-library
+    $ make cookiecutter-xblock
 
 Decisions
 ---------

--- a/cookiecutter-django-app/hooks/post_gen_project.py
+++ b/cookiecutter-django-app/hooks/post_gen_project.py
@@ -12,11 +12,7 @@ from edx_lint.cmd.write import write_main
 # cookiecutter can import a template from either github or from a location on local disk.
 # If someone is debugging this repository locally, the below block is necessary to pull in
 #   local versions of the templates
-EDX_COOKIECUTTER_ROOTDIR = os.getenv('EDX_COOKIECUTTER_ROOTDIR')
-import_template_from_github = True
-if EDX_COOKIECUTTER_ROOTDIR is not None and isinstance(EDX_COOKIECUTTER_ROOTDIR, str):
-    if len(EDX_COOKIECUTTER_ROOTDIR) > 0:
-        import_template_from_github = False
+EDX_COOKIECUTTER_ROOTDIR = os.getenv('EDX_COOKIECUTTER_ROOTDIR') or 'https://github.com/edx/edx-cookiecutters.git'
 
 
 def move(src, dest):
@@ -55,20 +51,12 @@ extra_context["requires_django"] = "yes"
 
 extra_context["placeholder_repo_name"] = python_placeholder_repo_name
 
-if import_template_from_github:
-    directory = "python-template"
-    cookiecutter(
-        'git@github.com:edx/edx-cookiecutters.git',
-        extra_context=extra_context,
-        no_input=True,
-        directory=directory
-        )
-else:
-    cookiecutter(
-        os.path.join(EDX_COOKIECUTTER_ROOTDIR, 'python-template'),
-        extra_context=extra_context,
-        no_input=True
-        )
+cookiecutter(
+    EDX_COOKIECUTTER_ROOTDIR,
+    extra_context=extra_context,
+    no_input=True,
+    directory='python-template',
+)
 
 
 # moving templated cookie-cutter output to root

--- a/cookiecutter-django-ida/hooks/post_gen_project.py
+++ b/cookiecutter-django-ida/hooks/post_gen_project.py
@@ -12,11 +12,7 @@ from edx_lint.cmd.write import write_main
 # cookiecutter can import a template from either github or from a location on local disk.
 # If someone is debugging this repository locally, the below block is necessary to pull in
 #   local versions of the templates
-EDX_COOKIECUTTER_ROOTDIR = os.getenv('EDX_COOKIECUTTER_ROOTDIR')
-import_template_from_github = True
-if EDX_COOKIECUTTER_ROOTDIR is not None and isinstance(EDX_COOKIECUTTER_ROOTDIR, str):
-    if len(EDX_COOKIECUTTER_ROOTDIR) > 0:
-        import_template_from_github = False
+EDX_COOKIECUTTER_ROOTDIR = os.getenv('EDX_COOKIECUTTER_ROOTDIR') or 'https://github.com/edx/edx-cookiecutters.git'
 
 
 def move(src, dest):
@@ -67,21 +63,12 @@ extra_context["open_source_license"] = "{{cookiecutter.open_source_license}}"
 
 extra_context["placeholder_repo_name"] = python_placeholder_repo_name
 
-#  get template from github
-if import_template_from_github:
-    directory = "python-template"
-    cookiecutter(
-        'git@github.com:edx/edx-cookiecutters.git',
-        extra_context=extra_context,
-        no_input=True,
-        directory=directory
-        )
-else:
-    cookiecutter(
-        os.path.join(EDX_COOKIECUTTER_ROOTDIR, 'python-template'),
-        extra_context=extra_context,
-        no_input=True
-        )
+cookiecutter(
+    EDX_COOKIECUTTER_ROOTDIR,
+    extra_context=extra_context,
+    no_input=True,
+    directory='python-template',
+)
 
 project_root_dir = os.getcwd()
 python_template_cookiecutter_output_loc = os.path.join(project_root_dir, python_placeholder_repo_name)

--- a/cookiecutter-python-library/hooks/post_gen_project.py
+++ b/cookiecutter-python-library/hooks/post_gen_project.py
@@ -12,11 +12,7 @@ from edx_lint.cmd.write import write_main
 # cookiecutter can import a template from either github or from a location on local disk.
 # If someone is debugging this repository locally, the below block is necessary to pull in
 #   local versions of the templates
-EDX_COOKIECUTTER_ROOTDIR = os.getenv('EDX_COOKIECUTTER_ROOTDIR')
-import_template_from_github = True
-if EDX_COOKIECUTTER_ROOTDIR is not None and isinstance(EDX_COOKIECUTTER_ROOTDIR, str):
-    if len(EDX_COOKIECUTTER_ROOTDIR) > 0:
-        import_template_from_github = False
+EDX_COOKIECUTTER_ROOTDIR = os.getenv('EDX_COOKIECUTTER_ROOTDIR') or 'https://github.com/edx/edx-cookiecutters.git'
 
 
 def move(src, dest):
@@ -49,20 +45,13 @@ extra_context["owner_name"] = "{{cookiecutter.owner_name}}"
 extra_context["open_source_license"] = "{{cookiecutter.open_source_license}}"
 
 extra_context["placeholder_repo_name"] = "placeholder_repo_name"
-if import_template_from_github:
-    directory = "python-template"
-    cookiecutter(
-        'git@github.com:edx/edx-cookiecutters.git',
-        extra_context=extra_context,
-        no_input=True,
-        directory=directory
-        )
-else:
-    cookiecutter(
-        os.path.join(EDX_COOKIECUTTER_ROOTDIR, 'python-template'),
-        extra_context=extra_context,
-        no_input=True
-        )
+
+cookiecutter(
+    EDX_COOKIECUTTER_ROOTDIR,
+    extra_context=extra_context,
+    no_input=True,
+    directory='python-template',
+)
 
 # moving templated cookie-cutter output to root
 project_root_dir = os.getcwd()

--- a/cookiecutter-xblock/hooks/post_gen_project.py
+++ b/cookiecutter-xblock/hooks/post_gen_project.py
@@ -12,11 +12,7 @@ from edx_lint.cmd.write import write_main
 # cookiecutter can import a template from either github or from a location on local disk.
 # If someone is debugging this repository locally, the below block is necessary to pull in
 #   local versions of the templates
-EDX_COOKIECUTTER_ROOTDIR = os.getenv('EDX_COOKIECUTTER_ROOTDIR')
-import_template_from_github = True
-if EDX_COOKIECUTTER_ROOTDIR is not None and isinstance(EDX_COOKIECUTTER_ROOTDIR, str):
-    if len(EDX_COOKIECUTTER_ROOTDIR) > 0:
-        import_template_from_github = False
+EDX_COOKIECUTTER_ROOTDIR = os.getenv('EDX_COOKIECUTTER_ROOTDIR') or 'https://github.com/edx/edx-cookiecutters.git'
 
 
 def move(src, dest):
@@ -57,20 +53,13 @@ setup_py_keyword_args = """entry_points={
 """
 extra_context["setup_py_keyword_args"] = setup_py_keyword_args
 extra_context["placeholder_repo_name"] = "placeholder_repo_name"
-if import_template_from_github:
-    directory = "python-template"
-    cookiecutter(
-        'git@github.com:edx/edx-cookiecutters.git',
-        extra_context=extra_context,
-        no_input=True,
-        directory=directory
-        )
-else:
-    cookiecutter(
-        os.path.join(EDX_COOKIECUTTER_ROOTDIR, 'python-template'),
-        extra_context=extra_context,
-        no_input=True
-        )
+
+cookiecutter(
+    EDX_COOKIECUTTER_ROOTDIR,
+    extra_context=extra_context,
+    no_input=True,
+    directory='python-template',
+)
 
 # moving templated cookie-cutter output to root
 project_root_dir = os.getcwd()


### PR DESCRIPTION
**Description:**

Simplify local development by adding `Makefile` targets.
Cleanup `ENV` var handling.

@jinder1s Thanks for your explanation on https://github.com/edx/edx-cookiecutters/pull/31 ;
I think I better understand how that works (github vs local).

I understand why we don't default to local (if people invoke it like `cookiecutter https://github.com/edx/edx-cookiecutters -d cookiecutter-xblock`, but it still felt a little "off" to me that running locally, especially after having run `make requirements` , you'd still need to remember to set the `ENV` variable.

So I created a `Makefile` target to invoke `cookiecutter` with all the right arguments, including the setting of `EDX_COOKIECUTTER_ROOTDIR`, by just typing `make cookiecutter-<my-template-name>`.

This leaves the default case in place (it pulls from github), but now if you run via the `Makefile`, which you can only do if you have the code checked out locally anyway, you get the expected developer experience :)

And while I was in there I cleaned up the way we were getting/setting the `ENV` variable; more details in the comments.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
