### PR TITLE
ARCHBOM-1328: Fix CSRF configuration by including csrf.urls patterns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,17 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
-2020-06-2
+2020-07-09
+----------
+
+Fixed
+~~~~~
+
+* Added csrf.urls to IDA cookiecutter so that CSRF works
+
+(some intervening changes not captured)
+
+2020-06-02
 ----------
 
 * Adding decision to make this repo the place for all edx cookiecutters.

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/urls.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     # Use the same auth views for all logins, including those originating from the browseable API.
     url(r'^api-auth/', include(oauth2_urlpatterns)),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
+    url(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
     url(r'^health/$', core_views.health, name='health'),
 ]
 


### PR DESCRIPTION
Some users of the cookiecutter discovered that we weren't fully configuring CSRF.

[ARCHBOM-1328](https://openedx.atlassian.net/browse/ARCHBOM-1328)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
