### PR TITLE
Update the default module path to be a valid path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PIP_COMPILE = pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
 
 TEMPLATES=$(wildcard cookiecutter-*)
 .PHONY: $(TEMPLATES)
-$(TEMPLATES): ## Create a new repo from the template
+$(TEMPLATES): requirements ## Create a new repo from the template
 	test -e var/ || mkdir var
 	EDX_COOKIECUTTER_ROOTDIR=$(PWD) cookiecutter $(PWD) --directory $(@) --output-dir var
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/manage.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/manage.py
@@ -9,7 +9,7 @@ import sys
 PWD = os.path.abspath(os.path.dirname(__file__))
 
 if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{cookiecutter.repo_name}}.settings.local')
     sys.path.append(PWD)
     try:
         from django.core.management import execute_from_command_line  # pylint: disable=wrong-import-position


### PR DESCRIPTION
This way after you bring up your IDA from a cookiecutter, you can
just run  without needing to specify settings every time.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
