### PR TITLE
MICROBA-404 Update oauth2_urlpatterns import in cookie cutter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2020-07-015
+----------
+
+Changed
+~~~~~~~
+
+* Changed how oauth2_urlpatterns is imported in the urls.py file
+
 2020-07-09
 ----------
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/urls.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/urls.py
@@ -27,12 +27,10 @@ from {{cookiecutter.repo_name}}.apps.core import views as core_views
 
 admin.autodiscover()
 
-urlpatterns = [
+urlpatterns = oauth2_urlpatterns + [
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include(api_urls)),
     url(r'^api-docs/', get_swagger_view(title='{{cookiecutter.repo_name}} API')),
-    # Use the same auth views for all logins, including those originating from the browseable API.
-    url(r'^api-auth/', include(oauth2_urlpatterns)),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
     url(r'^health/$', core_views.health, name='health'),


### PR DESCRIPTION
**Description:**

The @edx/edx-aperture team was running into a namespace warning in the Demographics IDA that turned out to be related to these `oauth2_urlpatterns` being imported twice. (You can see [that PR here](https://github.com/edx/demographics/pull/45).)

In the Demographics IDA, we call `oauth2_urlpatterns` as you see suggested here, and it is not included again at (what was previously here) ~ line 34:
```
url(r'^api-auth/', include(oauth2_urlpatterns)),
```

From a quick look, this proposed update to the cookie cutter seems to follow [the pattern suggested in edx/auth-backends](https://github.com/edx/auth-backends#authentication-views).

**JIRA:**

This very loosely comes out of [MICROBA-404](https://openedx.atlassian.net/browse/MICROBA-404).

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
