### PR TITLE
Fixing documentation in individual cookiecutters

### DIFF
--- a/cookiecutter-django-app/README.rst
+++ b/cookiecutter-django-app/README.rst
@@ -8,16 +8,10 @@ A cookiecutter_ template for creating reusable Django packages (installable apps
 If you're creating a standalone Django service, you should probably use
 `cookiecutter-django-ida`_ instead.
 
-**Why?** Creating reusable Django packages has always been annoying. There are no defined/maintained
-best practices (especially for ``setup.py``), so you end up cutting and pasting hacky, poorly understood,
-often legacy code from one project to the other. This template, inspired by `cookiecutter-djangopackage`_,
-is designed to allow Django developers the ability to break free from cargo-cult configuration and follow
-a common pattern dictated by the experts and maintained here.
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
-.. _cookiecutter-django-ida: https://github.com/edx/cookiecutter-django-ida
-.. _cookiecutter-pypackage: https://github.com/audreyr/cookiecutter-pypackage
-.. _cookiecutter-djangopackage: https://github.com/pydanny/cookiecutter-djangopackage
+.. _cookiecutter-django-ida: https://github.com/edx/edx-cookiecutters/cookiecutter-django-ida
+
 
 Features
 --------
@@ -47,49 +41,12 @@ badge, a travis-ci badge and a link to documentation on readthedocs.org. You
 don't need to have these accounts set up before using Cookiecutter or
 cookiecutter-django-app.
 
-Now, get Cookiecutter_. Trust me, it's awesome::
 
-    $ pip install cookiecutter
+To create project using this cookiecutter, follow instructions found in edx-cookiecutter's `readme`_.
 
-You also need to instll edx-lint for::
+.. _readme: https://github.com/edx/edx-cookiecutters/blob/master/README.rst
 
-    $ pip install edx-lint
-
-Now run it against this repo::
-
-    $ cookiecutter https://github.com/edx/edx-cookiecutters.git --directory cookiecutter-django-app
-
-You'll be prompted for some questions, answer them, then it will create a directory that is your new package.
-
-Let's pretend you want to create a reusable Django app called "Blogging-for-Humans", with an app that can be placed
-in ``INSTALLED_APPS`` as "blogging_for_humans". Rather than have to copy/paste from other people's projects and
-then fight enthusiasm-destroying app layout issues like `setup.py` configuration and creating test
-harnesses, you get Cookiecutter_ to do all the work.
-
-**Warning**: After this point, change 'John Doe', 'jdoe@edx.org', etc. to your own information.
-
-It prompts you for information that it uses to create the app, with defaults in square brackets. Answer them::
-
-    Cloning into 'cookiecutter-django-app'...
-    remote: Counting objects: 49, done.
-    remote: Compressing objects: 100% (33/33), done.
-    remote: Total 49 (delta 6), reused 48 (delta 5)
-    Unpacking objects: 100% (49/49), done.
-    full_name [Your full name here]: John Doe
-    email [you@example.com]: jdoe@edx.org
-    repo_name [blogging_for_humans]:
-    app_name [blogging_for_humans]:
-    project_name [dj-package]: Blogging-for-Humans
-    project_short_description [Your project description goes here]: A sample Django package
-    models [Comma-separated list of models]: Scoop, Flavor
-    config_class_name [BloggingForHumansConfig]:
-    version [0.1.0]:
-    owner [edx/platform-team]:
-    Select open_source_license:
-    1 - AGPL
-    2 - Apache Software License 2.0
-    3 - Not open source
-    Choose from 1, 2, 3 [1]:
+After the new folder is created, you will need to:
 
 Enter the project and take a look around::
 

--- a/cookiecutter-django-app/README.rst
+++ b/cookiecutter-django-app/README.rst
@@ -42,7 +42,7 @@ don't need to have these accounts set up before using Cookiecutter or
 cookiecutter-django-app.
 
 
-To create project using this cookiecutter, follow instructions found in edx-cookiecutter's `readme`_.
+To create a project using this cookiecutter, follow the instructions found in edx-cookiecutter's `readme`_.
 
 .. _readme: https://github.com/edx/edx-cookiecutters/blob/master/README.rst
 

--- a/cookiecutter-django-ida/README.rst
+++ b/cookiecutter-django-ida/README.rst
@@ -27,39 +27,11 @@ The necessary configuration is also in place to support:
 Usage
 -----
 
-As with any new project, you will need to create a virtual environment. Once this is set up, install cookiecutter and edx-lint:
 
-.. code-block:: bash
+To create project using this cookiecutter, follow instructions found in edx-cookiecutter's `readme`_.
 
-    $ pip install cookiecutter
-    $ pip install edx-lint
+.. _readme: https://github.com/edx/edx-cookiecutters/blob/master/README.rst
 
-cookiecutter has the ability to pull templates directly from git, so there is no need to clone this repo. To access the template, provide the repo path as an argument:
-
-.. code-block:: bash
-
-    $ cd <workspace>
-    $ cookiecutter https://github.com/edx/edx-cookiecutters.git --directory cookiecutter-django-ida
-
-You will be prompted for a few basic details (described below). These will be used to create the new project.
-
-..  list-table::
-    :widths: 25 75
-    :header-rows: 1
-
-    * - repo_name
-      - Short (Python-friendly) name of the project. This should also be the name of the repository (e.g., ecommerce, credentials).
-    * - project_name
-      - Full name of the project. (e.g., E-Commerce Service)
-    * - project_short_description
-    * - author_name
-    * - author_email
-    * - owner_type
-      - two options: team or repo. Is a team directly owning it, or is this cookiecutter output only used by one repository?
-    * - owner_name
-      - the name of either the team or repository that is owning this
-    * - port
-      - Port number for the project. Should be in the form `18***` with the 3 digits being any that aren't currently in use by other services.
 
 After the new folder is created, you will need to:
 

--- a/cookiecutter-django-ida/README.rst
+++ b/cookiecutter-django-ida/README.rst
@@ -28,7 +28,7 @@ Usage
 -----
 
 
-To create project using this cookiecutter, follow instructions found in edx-cookiecutter's `readme`_.
+To create a project using this cookiecutter, follow the instructions found in edx-cookiecutter's `readme`_.
 
 .. _readme: https://github.com/edx/edx-cookiecutters/blob/master/README.rst
 

--- a/cookiecutter-python-library/README.rst
+++ b/cookiecutter-python-library/README.rst
@@ -12,7 +12,7 @@ This cookiecutter template is intended for new edX python libraries.
 Usage
 -----
 
-To create project using this cookiecutter, follow instructions found in edx-cookiecutter's `readme`_.
+To create a project using this cookiecutter, follow the instructions found in edx-cookiecutter's `readme`_.
 
 .. _readme: https://github.com/edx/edx-cookiecutters/blob/master/README.rst
 

--- a/cookiecutter-python-library/README.rst
+++ b/cookiecutter-python-library/README.rst
@@ -12,21 +12,9 @@ This cookiecutter template is intended for new edX python libraries.
 Usage
 -----
 
-As with any new project, you will need to create a virtual environment. Once this is set up, install cookiecutter and edx-lint:
+To create project using this cookiecutter, follow instructions found in edx-cookiecutter's `readme`_.
 
-.. code-block:: bash
-
-    $ pip install cookiecutter
-    $ pip install edx-lint
-
-cookiecutter has the ability to pull templates directly from git, so there is no need to clone this repo. To access the template, provide the repo path as an argument:
-
-.. code-block:: bash
-
-    $ cd <workspace>
-    $ cookiecutter https://github.com/edx/edx-cookiecutters.git --directory cookiecutter-python-library
-
-You will be prompted for a few basic details (described below). These will be used to create the new project.
+.. _readme: https://github.com/edx/edx-cookiecutters/blob/master/README.rst
 
 After the new folder is created, you will need to:
 

--- a/cookiecutter-xblock/README.rst
+++ b/cookiecutter-xblock/README.rst
@@ -2,12 +2,10 @@ This is a cookiecutter template for new XBlocks.
 
 It enables creation of the XBlock repository as well as a Dockerfile for building and running your XBlock in the xblock-sdk workbench.
 
-To create a new XBlock using this cookiecutter template, first make sure you have cookiecutter installed.
+To create a new XBlock using this cookiecutter template, follow the instructions found in edx-cookiecutter's `readme`_.
 
-Then run::
+.. _readme: https://github.com/edx/edx-cookiecutters/blob/master/README.rst
 
-    $ cd <workspace>
-    $ cookiecutter https://github.com/edx/edx-cookiecutters.git --directory cookiecutter-python-library
 
 Enter the short name and primary class name of your new XBlock when prompted.
 


### PR DESCRIPTION
**Description:**

The readmes for the individual cookiecutters were slightly wrong and overly verbose, removed something that did not seem necessary.

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
