### PR TITLE
removed deprecated features to make the output compatible with python 3.8

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/models.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/models.py
@@ -3,12 +3,10 @@ Database models for {{cookiecutter.app_name}}.
 """
 {%- if cookiecutter.models != "Comma-separated list of models" %}
 # from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from model_utils.models import TimeStampedModel
 {%- for model in cookiecutter.models.replace(' ', '').split(',') %}
 
 
-@python_2_unicode_compatible
 class {{ model.strip() }}(TimeStampedModel):
     """
     TODO: replace with a brief description of the model.

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/core/models.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/core/models.py
@@ -2,7 +2,6 @@
 
 from django.contrib.auth.models import AbstractUser
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -34,6 +33,5 @@ class User(AbstractUser):
     def get_full_name(self):
         return self.full_name or super(User, self).get_full_name()
 
-    @python_2_unicode_compatible
     def __str__(self):
         return str(self.get_full_name())

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/docker_gunicorn_configuration.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/docker_gunicorn_configuration.py
@@ -3,7 +3,6 @@ gunicorn configuration file: https://docs.gunicorn.org/en/develop/configure.html
 """
 import multiprocessing  # pylint: disable=unused-import
 
-
 preload_app = True
 timeout = 300
 bind = "0.0.0.0:{{cookiecutter.port}}"
@@ -47,6 +46,7 @@ def close_all_caches():
 
 def post_fork(server, worker):  # pylint: disable=unused-argument
     close_all_caches()
+
 
 def when_ready(server):  # pylint: disable=unused-argument
     """When running in debug mode, run Django's `check` to better match what `manage.py runserver` does"""

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/base.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/base.py
@@ -60,7 +60,6 @@ MIDDLEWARE = (
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',


### PR DESCRIPTION
**Description:**
This PR intends to remove some deprecated features. (when an app is generated using `cookiecutter-django-ida` template with python 3.8 it installs Django 3 by default and it fails on following features)

1. `SessionAuthenticationMiddleware` was removed in Django 2.0 ([ref](https://docs.djangoproject.com/en/3.0/releases/2.0/#miscellaneous))
2. `python_2_unicode_compatible` decorator is removed in Django 3.0 ([ref](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis))

**JIRA:**
https://openedx.atlassian.net/browse/BOM-1952

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
