### PR TITLE
Include JWT_AUTH_COOKIE in the base JWT_AUTH settings.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,15 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
-2020-07-015
+2020-07-28
+----------
+
+Fixed
+~~~~~~~
+
+* Include ``JWT_AUTH_COOKIE`` in the base ``JWT_AUTH`` settings dict.
+
+2020-07-15
 ----------
 
 Changed

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/base.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/base.py
@@ -208,6 +208,7 @@ JWT_AUTH = {
     'JWT_LEEWAY': 1,
     'JWT_DECODE_HANDLER': 'edx_rest_framework_extensions.auth.jwt.decoder.jwt_decode_handler',
     'JWT_PUBLIC_SIGNING_JWK_SET': None,
+    'JWT_AUTH_COOKIE': 'edx-jwt-cookie',
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
     'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',


### PR DESCRIPTION
**Description:**

`JWT_AUTH_COOKIE` name is required for our JWT Authentication tools, which expect a JWT token to be present in some request cookie.  `JWT_AUTH_COOKIE` specifies the name of the cookie to look for.

**Merge checklist:**
- [x] All reviewers approved
- [ ] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
