### PR TITLE
remove max-line-length for doc8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,16 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2020-08-03
+----------
+
+Fixed
+~~~~~~~
+
+* Doc8 configs no longer have a max line length, which goes against our best practice to not use hard line breaks, as documented in `OEP-19: Developer Documentation Best Practices`_.
+
+.. _`OEP-19: Developer Documentation Best Practices`: https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html#best-practices
+
 2020-07-28
 ----------
 

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/tox.ini
@@ -2,7 +2,8 @@
 envlist = {py35,py38}-django{111,20,21,22}
 
 [doc8]
-max-line-length = 120
+; D001 = Line too long
+ignore=D001
 
 [pycodestyle]
 exclude = .git,.tox,migrations

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/tox.ini
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/tox.ini
@@ -2,7 +2,8 @@
 envlist = py{35,36,37,38}
 
 [doc8]
-max-line-length = 120
+; D001 = Line too long
+ignore=D001
 
 [pycodestyle]
 exclude = .git,.tox


### PR DESCRIPTION
**Description:**

Our best practice for docs is to not use
hard line breaks, and to let editors wrap.

See https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html#best-practices

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
