### PR TITLE
Updates to READMEs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,17 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2020-08-07
+----------
+
+Fixed
+~~~~~
+
+- Tweaks to the READMEs to separate using cookiecutters from updating
+  cookiecutters; clarify the use of a virtualenv for running cookiecutters;
+  correct the way we talk about Slack and getting help; minor formatting
+  improvements.
+
 2020-08-03
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -2,26 +2,32 @@
 edx-cookiecutters
 =================
 
-This repository holds most of the Open edx public cookiecutters.
+This repository holds most of the Open edX public cookiecutters.
 
-If you are modifying and debugging cookiecutters on a local device, please see "Local Debugging of the layered cookiecutters" section below.
+Using the cookiecutters
+***********************
+
 
 Available cookiecutters
 ------------------------
 
-- cookiecutter-django-ida
-    - intended for new edX independently deployable apps (IDAs)
-- cookiecutter-django-app
-    - for creating reusable Django packages (installable apps)
-- cookiecutter-python-library
-    - for creating a python package that follows edx standards
-- cookiecutter-xblock
-    - for createing a XBlock repository as well as a Dockerfile for building and running your XBlock in the xblock-sdk workbench.
+cookiecutter-django-ida
+    for creating new independently deployable apps (IDAs).
+
+cookiecutter-django-app
+    for creating reusable Django packages (installable apps).
+
+cookiecutter-python-library
+    for creating a Python package that follows Open edX standards.
+
+cookiecutter-xblock
+    for creating a XBlock repository as well as a Dockerfile for building and running your XBlock in the xblock-sdk workbench.
 
 
 Using a cookiecutter
 --------------------
-These instructions assume you have cloned this repository and are currently in its head dir.
+
+These instructions assume you have cloned this repository and are currently in its head dir. You will need a virtualenv for running the cookiecutter. You can discard it once the cookiecutter has made your new repo.
 
 Commands::
 
@@ -31,9 +37,14 @@ Commands::
 
 TODOs after creating cookiecutter
 --------------------------------
+
 - Modify project README
 - Modify project docs/decisions/0001-purpose-of-this-repo.rst ADR
 
+Updating cookiecutters
+**********************
+
+If you are modifying and debugging cookiecutters on a local device, please see "Local Debugging of the layered cookiecutters" section below.
 
 Cookiecutters using layered apporach
 ------------------------------------
@@ -49,7 +60,7 @@ Local Debugging of the layered cookiecutters
 --------------------------------------------
 
 To ensure that the layered cookiecutters pull from your local code,
-instead of Github, run cookiecutter like::
+instead of GitHub, run cookiecutter like::
 
     $ make cookiecutter-<TEMPLATE-NAME>
 
@@ -65,10 +76,13 @@ Decisions
 
 See docs/decisions/0003-layered-cookiecutter.rst for details on layering cookiecutters to share boilerplate files.
 
+Community
+*********
+
 Contributing
 ------------
-Contributions are very welcome. Tests can be run with `tox`_, please ensure
-the coverage at least stays the same before you submit a pull request.
+
+Contributions are very welcome. Tests can be run with `tox`_. Please ensure the coverage at least stays the same before you submit a pull request.
 
 License
 -------
@@ -87,16 +101,13 @@ Please do not report security issues in public. Please email security@edx.org.
 Getting Help
 ------------
 
-If you're having trouble, we have discussion forums at
-https://discuss.openedx.org where you can connect with others in the community.
+If you're having trouble, we have discussion forums at https://discuss.openedx.org where you can connect with others in the community.
 
-Our real-time conversations are on Slack. You can request a `Slack
-invitation`_, then join our `community Slack team`_.
+Our real-time conversations are on Slack. You can request a `Slack invitation`_, then join our `community Slack workspace`_.
 
 For more information about these options, see the `Getting Help`_ page.
 
 .. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
-.. _community Slack team: https://openedx.slack.com/
+.. _community Slack workspace: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help
-.. _`file an issue`: https://github.com/edx/edx-cookiecutters/issues
-.. _`tox`: https://tox.readthedocs.io/en/latest/
+.. _tox: https://tox.readthedocs.io/en/latest/

--- a/cookiecutter-django-ida/README.rst
+++ b/cookiecutter-django-ida/README.rst
@@ -100,7 +100,15 @@ Reporting Security Issues
 
 Please do not report security issues in public. Please email security@edx.org.
 
-Get Help
---------
+Getting Help
+------------
 
-Ask questions and discuss this project on `Slack <https://openedx.slack.com/messages/general/>`_ or in the `edx-code Google Group <https://groups.google.com/forum/#!forum/edx-code>`_.
+If you're having trouble, we have discussion forums at https://discuss.openedx.org where you can connect with others in the community.
+
+Our real-time conversations are on Slack. You can request a `Slack invitation`_, then join our `community Slack workspace`_.
+
+For more information about these options, see the `Getting Help`_ page.
+
+.. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
+.. _community Slack workspace: https://openedx.slack.com/
+.. _Getting Help: https://openedx.org/getting-help

--- a/cookiecutter-python-library/README.rst
+++ b/cookiecutter-python-library/README.rst
@@ -67,7 +67,15 @@ Reporting Security Issues
 
 Please do not report security issues in public. Please email security@edx.org.
 
-Get Help
---------
+Getting Help
+------------
 
-Ask questions and discuss this project on `Slack <https://openedx.slack.com/messages/general/>`_ or in the `edx-code Google Group <https://groups.google.com/forum/#!forum/edx-code>`_.
+If you're having trouble, we have discussion forums at https://discuss.openedx.org where you can connect with others in the community.
+
+Our real-time conversations are on Slack. You can request a `Slack invitation`_, then join our `community Slack workspace`_.
+
+For more information about these options, see the `Getting Help`_ page.
+
+.. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
+.. _community Slack workspace: https://openedx.slack.com/
+.. _Getting Help: https://openedx.org/getting-help

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -53,16 +53,14 @@ Please do not report security issues in public. Please email security@edx.org.
 Getting Help
 ------------
 
-If you're having trouble, we have discussion forums at
-https://discuss.openedx.org where you can connect with others in the community.
+If you're having trouble, we have discussion forums at https://discuss.openedx.org where you can connect with others in the community.
 
-Our real-time conversations are on Slack. You can request a `Slack
-invitation`_, then join our `community Slack team`_.
+Our real-time conversations are on Slack. You can request a `Slack invitation`_, then join our `community Slack workspace`_.
 
 For more information about these options, see the `Getting Help`_ page.
 
 .. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
-.. _community Slack team: https://openedx.slack.com/
+.. _community Slack workspace: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help
 
 .. |pypi-badge| image:: https://img.shields.io/pypi/v/{{ cookiecutter.repo_name }}.svg


### PR DESCRIPTION
- Add some clarification about using a virtualenv for running
  cookiecutter.

- Separate the main README into Using and Updating sections.

- Correct the way we talk about Slack, and getting help.

- Minor tweaks to RST formatting.

