### PR TITLE
Ignore healthcheck transaction in IDA cookiecutter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2020-08-14
+----------
+
+Changed
+~~~~~~~
+
+* Ignores /healthcheck endpoint in monitoring for IDAs
+
 2020-08-07
 ----------
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/core/views.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/core/views.py
@@ -8,6 +8,7 @@ from django.db import DatabaseError, connection, transaction
 from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
 from django.views.generic import View
+from edx_django_utils.monitoring import ignore_transaction
 
 from {{cookiecutter.repo_name}}.apps.core.constants import Status
 
@@ -33,6 +34,9 @@ def health(_):
         >>> response.content
         '{"overall_status": "OK", "detailed_status": {"database_status": "OK", "lms_status": "OK"}}'
     """
+
+    # Ignores health check in performance monitoring so as to not artifically inflate our response time metrics
+    ignore_transaction()
 
     try:
         cursor = connection.cursor()


### PR DESCRIPTION
**Description:**

Ignore the /healthcheck endpoint by default in monitoring so our
transaction times are closer to what the end user sees.

**JIRA:**

N/A

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
