### PR TITLE
Fix the DATABASES settings in devstack.py of the django-ida cookiecutter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2020-09-09
+----------
+
+Changed
+~~~~~~~
+
+* Fix the ``DATABASES`` settings in ``devstack.py`` of the django-ida cookiecutter.
+
 2020-08-26
 ----------
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/devstack.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/devstack.py
@@ -6,7 +6,7 @@ DATABASES = {
         'NAME': os.environ.get('DB_NAME', '{{cookiecutter.project_name}}'),
         'USER': os.environ.get('DB_USER', 'root'),
         'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-        'HOST': os.environ.get('DB_HOST', '{{cookiecutter.project_name.db'),
+        'HOST': os.environ.get('DB_HOST', '{{cookiecutter.project_name.db}}'),
         'PORT': os.environ.get('DB_PORT', 3306),
         'ATOMIC_REQUESTS': False,
         'CONN_MAX_AGE': 60,


### PR DESCRIPTION
**Description:**

Fix the ``DATABASES`` settings in ``devstack.py`` of the django-ida cookiecutter.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
