### PR TITLE
pin importlib-metadata to 1.7.0 for python35

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,3 +19,6 @@ django<3.0
 pyobjc-core; sys_platform == 'darwin'
 pyobjc-framework-cocoa; sys_platform == 'darwin'
 pyobjc-framework-fsevents; sys_platform == 'darwin'
+
+# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python35
+importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,7 +11,7 @@ astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.2.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via -r requirements/test.txt, sphinx
 binaryornot==0.4.4        # via -r requirements/test.txt, cookiecutter
-bleach==3.2.0             # via -r requirements/test.txt, readme-renderer
+bleach==3.2.1             # via -r requirements/test.txt, readme-renderer
 certifi==2020.6.20        # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, binaryornot, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
@@ -27,7 +27,7 @@ edx-sphinx-theme==1.5.0   # via -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via -r requirements/test.txt, sphinx
-importlib-metadata==1.7.0  # via -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 isort==4.3.21             # via -r requirements/test.txt, pylint
 jinja2-time==0.2.0        # via -r requirements/test.txt, cookiecutter

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ astroid==2.3.3            # via -r requirements/base.txt, pylint, pylint-celery
 attrs==20.2.0             # via pytest
 babel==2.8.0              # via sphinx
 binaryornot==0.4.4        # via -r requirements/base.txt, cookiecutter
-bleach==3.2.0             # via readme-renderer
+bleach==3.2.1             # via readme-renderer
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, binaryornot, doc8, requests
 click-log==0.3.2          # via -r requirements/base.txt, edx-lint
@@ -24,7 +24,7 @@ edx-lint==1.5.2           # via -r requirements/base.txt, -r requirements/test.i
 edx-sphinx-theme==1.5.0   # via -r requirements/test.in
 idna==2.10                # via -r requirements/base.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/base.txt, -r requirements/test.in, pylint
 jinja2-time==0.2.0        # via -r requirements/base.txt, cookiecutter
 jinja2==2.11.2            # via -r requirements/base.txt, cookiecutter, jinja2-time, sphinx

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,7 +7,7 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox


### PR DESCRIPTION
- Pinned `importlib-metadata==1.7.0` as `version>1.7.0` is causing conflicts for python35 in running `make upgrade`.

Note: 
According to the discussion on https://github.com/edx/edx-cookiecutters/pull/65 by @feanil, tests on python35 are failing because of the older version of `importlib-metadata` and we'll have to wait for the `tox` update for this issue to be resolved. 
So pinning this package version unless we have a fix for the tests because it is causing the automated package upgrade jobs to fail.