### PR TITLE
ARCHBOM-1570: Don't fill in a sample url pattern for Django apps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2020-10-30
+----------
+
+Fixed
+~~~~~
+
+* Don't fill in a sample url pattern for Django apps, just suggest one in a comment
+
 2020-08-26
 ----------
 

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/urls.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/urls.py
@@ -1,8 +1,8 @@
 """
 URLs for {{ cookiecutter.app_name }}.
 """
-from django.conf.urls import url  # pylint disable=unused-import
-from django.views.generic import TemplateView  # pylint disable=unused-import
+from django.conf.urls import url  # pylint: disable=unused-import
+from django.views.generic import TemplateView  # pylint: disable=unused-import
 
 urlpatterns = [
     # TODO: Fill in URL patterns and views here.

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/urls.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/urls.py
@@ -1,9 +1,10 @@
 """
 URLs for {{ cookiecutter.app_name }}.
 """
-from django.conf.urls import url
-from django.views.generic import TemplateView
+from django.conf.urls import url  # pylint disable=unused-import
+from django.views.generic import TemplateView  # pylint disable=unused-import
 
 urlpatterns = [
-    url(r'', TemplateView.as_view(template_name="{{ cookiecutter.app_name }}/base.html")),
+    # TODO: Fill in URL patterns and views here.
+    # url(r'', TemplateView.as_view(template_name="{{ cookiecutter.app_name }}/base.html")),
 ]


### PR DESCRIPTION
Just make it a suggestion in a comment, otherwise this can cause
trouble if the app is integrated before the `urlpatterns` list
is customized. (In particular, the `r''` default was overriding
all URLs in the IDA.)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed
