### PR TITLE
ARCHBOM-1597: Use a virtualenv for `make upgrade` in generated project

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2020-11-05
+----------
+
+Fixed
+~~~~~
+
+* Use virtualenv to prevent flakiness in ``make upgrade`` test
+
 2020-10-30
 ----------
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via -r requirements/test.txt, sphinx
-appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
+appdirs==1.4.4            # via -r requirements/test.txt, -r requirements/travis.txt, virtualenv
 arrow==0.13.2             # via -c requirements/constraints.txt, -r requirements/test.txt, jinja2-time, pytest-cookies
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.2.0             # via -r requirements/test.txt, pytest
@@ -17,14 +17,14 @@ chardet==3.0.4            # via -r requirements/test.txt, binaryornot, doc8, req
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, cookiecutter, edx-lint, pip-tools
 cookiecutter==1.7.2       # via -r requirements/test.txt, pytest-cookies
-distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
+distlib==0.3.1            # via -r requirements/test.txt, -r requirements/travis.txt, virtualenv
 django-model-utils==4.0.0  # via -r requirements/test.txt
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils
 doc8==0.8.1               # via -r requirements/test.txt
 docutils==0.16            # via -r requirements/test.txt, doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-lint==1.5.2           # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/test.txt
-filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
+filelock==3.0.12          # via -r requirements/test.txt, -r requirements/travis.txt, tox, virtualenv
 idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via -r requirements/test.txt, sphinx
 isort==4.3.21             # via -r requirements/test.txt, pylint
@@ -33,7 +33,7 @@ jinja2==2.11.2            # via -r requirements/test.txt, cookiecutter, jinja2-t
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, cookiecutter, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
-more-itertools==8.5.0     # via -r requirements/test.txt, pytest
+more-itertools==8.6.0     # via -r requirements/test.txt, pytest
 packaging==20.4           # via -r requirements/test.txt, -r requirements/travis.txt, bleach, pytest, sphinx, tox
 pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pip-tools==5.3.1          # via -r requirements/pip-tools.txt
@@ -42,7 +42,7 @@ poyo==0.5.0               # via -r requirements/test.txt, cookiecutter
 py==1.9.0                 # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/test.txt
 pydocstyle==5.1.1         # via -r requirements/test.txt
-pygments==2.7.1           # via -r requirements/test.txt, doc8, readme-renderer, sphinx
+pygments==2.7.2           # via -r requirements/test.txt, doc8, readme-renderer, sphinx
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
@@ -52,15 +52,15 @@ pytest-cookies==0.5.1     # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cookies
 python-dateutil==2.8.1    # via -r requirements/test.txt, arrow
 python-slugify==4.0.1     # via -r requirements/test.txt, cookiecutter
-pytz==2020.1              # via -r requirements/test.txt, babel, django
+pytz==2020.4              # via -r requirements/test.txt, babel, django
 readme-renderer==28.0     # via -r requirements/test.txt
 requests==2.24.0          # via -r requirements/test.txt, cookiecutter, sphinx
 restructuredtext-lint==1.3.1  # via -r requirements/test.txt, doc8
-sh==1.14.0                # via -r requirements/test.txt
+sh==1.14.1                # via -r requirements/test.txt
 six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, bleach, cookiecutter, doc8, edx-lint, edx-sphinx-theme, packaging, pip-tools, python-dateutil, readme-renderer, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/test.txt, pydocstyle, sphinx
 sphinx-rtd-theme==0.5.0   # via -r requirements/test.txt
-sphinx==3.2.1             # via -r requirements/test.txt, edx-sphinx-theme, sphinx-rtd-theme
+sphinx==3.3.0             # via -r requirements/test.txt, edx-sphinx-theme, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.2  # via -r requirements/test.txt, sphinx
 sphinxcontrib-devhelp==1.0.2  # via -r requirements/test.txt, sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via -r requirements/test.txt, sphinx
@@ -70,11 +70,11 @@ sphinxcontrib-serializinghtml==1.1.4  # via -r requirements/test.txt, sphinx
 sqlparse==0.4.1           # via -r requirements/test.txt, django
 stevedore==3.2.2          # via -r requirements/test.txt, doc8
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
-toml==0.10.1              # via -r requirements/travis.txt, tox
+toml==0.10.2              # via -r requirements/travis.txt, tox
 tox-battery==0.6.1        # via -r requirements/dev.in
 tox==3.20.1               # via -r requirements/travis.txt, tox-battery
 urllib3==1.25.11          # via -r requirements/test.txt, requests
-virtualenv==20.0.35       # via -r requirements/travis.txt, tox
+virtualenv==20.1.0        # via -r requirements/test.txt, -r requirements/travis.txt, tox
 wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/test.txt, bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -16,3 +16,4 @@ sh                        # Used to execute flake8 in tests
 Sphinx                    # Documentation builder
 sphinx_rtd_theme          # For pylint import checks of the generated conf.py
 doc8                      # reStructuredText style checker
+virtualenv                # To create a virtualenv when running commands in generated projects

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,7 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
+appdirs==1.4.4            # via virtualenv
 arrow==0.13.2             # via -c requirements/constraints.txt, -r requirements/base.txt, jinja2-time, pytest-cookies
 astroid==2.3.3            # via -r requirements/base.txt, pylint, pylint-celery
 attrs==20.2.0             # via pytest
@@ -16,12 +17,14 @@ chardet==3.0.4            # via -r requirements/base.txt, binaryornot, doc8, req
 click-log==0.3.2          # via -r requirements/base.txt, edx-lint
 click==7.1.2              # via -r requirements/base.txt, click-log, cookiecutter, edx-lint
 cookiecutter==1.7.2       # via -r requirements/base.txt, pytest-cookies
+distlib==0.3.1            # via virtualenv
 django-model-utils==4.0.0  # via -r requirements/test.in
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.in, django-model-utils
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.in, django-model-utils
 doc8==0.8.1               # via -r requirements/test.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-lint==1.5.2           # via -r requirements/base.txt, -r requirements/test.in
 edx-sphinx-theme==1.5.0   # via -r requirements/test.in
+filelock==3.0.12          # via virtualenv
 idna==2.10                # via -r requirements/base.txt, requests
 imagesize==1.2.0          # via sphinx
 isort==4.3.21             # via -r requirements/base.txt, -r requirements/test.in, pylint
@@ -30,7 +33,7 @@ jinja2==2.11.2            # via -r requirements/base.txt, cookiecutter, jinja2-t
 lazy-object-proxy==1.4.3  # via -r requirements/base.txt, astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, cookiecutter, jinja2
 mccabe==0.6.1             # via -r requirements/base.txt, pylint
-more-itertools==8.5.0     # via pytest
+more-itertools==8.6.0     # via pytest
 packaging==20.4           # via bleach, pytest, sphinx
 pbr==5.5.1                # via stevedore
 pluggy==0.13.1            # via pytest
@@ -38,7 +41,7 @@ poyo==0.5.0               # via -r requirements/base.txt, cookiecutter
 py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via -r requirements/test.in
 pydocstyle==5.1.1         # via -r requirements/test.in
-pygments==2.7.1           # via doc8, readme-renderer, sphinx
+pygments==2.7.2           # via doc8, readme-renderer, sphinx
 pylint-celery==0.3        # via -r requirements/base.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/base.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/base.txt, pylint-celery, pylint-django
@@ -48,15 +51,15 @@ pytest-cookies==0.5.1     # via -r requirements/test.in
 pytest==5.4.3             # via pytest-cookies
 python-dateutil==2.8.1    # via -r requirements/base.txt, arrow
 python-slugify==4.0.1     # via -r requirements/base.txt, cookiecutter
-pytz==2020.1              # via babel, django
+pytz==2020.4              # via babel, django
 readme-renderer==28.0     # via -r requirements/test.in
 requests==2.24.0          # via -r requirements/base.txt, cookiecutter, sphinx
 restructuredtext-lint==1.3.1  # via doc8
-sh==1.14.0                # via -r requirements/test.in
-six==1.15.0               # via -r requirements/base.txt, astroid, bleach, cookiecutter, doc8, edx-lint, edx-sphinx-theme, packaging, python-dateutil, readme-renderer
+sh==1.14.1                # via -r requirements/test.in
+six==1.15.0               # via -r requirements/base.txt, astroid, bleach, cookiecutter, doc8, edx-lint, edx-sphinx-theme, packaging, python-dateutil, readme-renderer, virtualenv
 snowballstemmer==2.0.0    # via pydocstyle, sphinx
 sphinx-rtd-theme==0.5.0   # via -r requirements/test.in
-sphinx==3.2.1             # via -r requirements/test.in, edx-sphinx-theme, sphinx-rtd-theme
+sphinx==3.3.0             # via -r requirements/test.in, edx-sphinx-theme, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -67,6 +70,7 @@ sqlparse==0.4.1           # via django
 stevedore==3.2.2          # via doc8
 text-unidecode==1.3       # via -r requirements/base.txt, python-slugify
 urllib3==1.25.11          # via -r requirements/base.txt, requests
+virtualenv==20.1.0        # via -r requirements/test.in
 wcwidth==0.2.5            # via pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/base.txt, astroid

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,6 +12,6 @@ pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
-toml==0.10.1              # via tox
+toml==0.10.2              # via tox
 tox==3.20.1               # via -r requirements/travis.in
-virtualenv==20.0.35       # via tox
+virtualenv==20.1.0        # via tox

--- a/test_utils/venv.py
+++ b/test_utils/venv.py
@@ -1,0 +1,19 @@
+"""
+Utilities for managing virtualenvs in tests.
+"""
+
+import shutil
+import subprocess
+import sys
+
+def run_in_virtualenv(shell_script):
+    """
+    Set up virtualenv in current directory and run provided shell script
+    with virtualenv active. Virtualenv is deleted after script runs.
+    """
+    try:
+        subprocess.check_call(['virtualenv', '-p', sys.executable, '--clear', '.venv'])
+        subprocess.check_call('. .venv/bin/activate; ' + shell_script, env={}, shell=True)
+    finally:
+        if shutil.rmtree.avoids_symlink_attacks:
+            shutil.rmtree('.venv', ignore_errors=True)

--- a/tests/test_cookiecutter_django_app.py
+++ b/tests/test_cookiecutter_django_app.py
@@ -13,6 +13,7 @@ import pytest
 import sh
 
 from test_utils.bake import bake_in_temp_dir
+from test_utils.venv import run_in_virtualenv
 
 LOGGING_CONFIG = {
     'version': 1,
@@ -145,10 +146,7 @@ def test_setup_py(options_baked):
 def test_upgrade(options_baked):
     """Make sure the upgrade target works"""
     try:
-        new_env = os.environ.copy()
-        new_env["PIP_COMPILE_OPTS"] = "-q"
-        # Sanity check the generated Makefile
-        sh.make('upgrade', _env=new_env)
+        run_in_virtualenv('make upgrade')
     except sh.ErrorReturnCode as exc:
         pytest.fail(str(exc.stderr))
 

--- a/tests/test_cookiecutter_django_ida.py
+++ b/tests/test_cookiecutter_django_ida.py
@@ -12,6 +12,7 @@ import pytest
 import sh
 
 from test_utils.bake import bake_in_temp_dir
+from test_utils.venv import run_in_virtualenv
 
 LOGGING_CONFIG = {
     'version': 1,
@@ -95,10 +96,7 @@ def test_travis(options_baked):
 def test_upgrade(options_baked):
     """Make sure the upgrade target works"""
     try:
-        new_env = os.environ.copy()
-        new_env["PIP_COMPILE_OPTS"] = "-q"
-        # Sanity check the generated Makefile
-        sh.make('upgrade', _env=new_env)
+        run_in_virtualenv('make upgrade')
     except sh.ErrorReturnCode as exc:
         pytest.fail(str(exc.stderr))
 

--- a/tests/test_cookiecutter_python_library.py
+++ b/tests/test_cookiecutter_python_library.py
@@ -13,6 +13,7 @@ import pytest
 import sh
 
 from test_utils.bake import bake_in_temp_dir
+from test_utils.venv import run_in_virtualenv
 
 LOGGING_CONFIG = {
     'version': 1,
@@ -109,10 +110,7 @@ def test_setup_py(options_baked):
 def test_upgrade(options_baked):
     """Make sure the upgrade target works"""
     try:
-        new_env = os.environ.copy()
-        new_env["PIP_COMPILE_OPTS"] = "-q"
-        # Sanity check the generated Makefile
-        sh.make('upgrade', _env=new_env)
+        run_in_virtualenv('make upgrade')
     except sh.ErrorReturnCode as exc:
         pytest.fail(str(exc.stderr))
 

--- a/tests/test_cookiecutter_xblock.py
+++ b/tests/test_cookiecutter_xblock.py
@@ -13,6 +13,7 @@ import pytest
 import sh
 
 from test_utils.bake import bake_in_temp_dir
+from test_utils.venv import run_in_virtualenv
 
 LOGGING_CONFIG = {
     'version': 1,
@@ -109,10 +110,7 @@ def test_setup_py(options_baked):
 def test_upgrade(options_baked):
     """Make sure the upgrade target works"""
     try:
-        new_env = os.environ.copy()
-        new_env["PIP_COMPILE_OPTS"] = "-q"
-        # Sanity check the generated Makefile
-        sh.make('upgrade', _env=new_env)
+        run_in_virtualenv('make upgrade')
     except sh.ErrorReturnCode as exc:
         pytest.fail(str(exc.stderr))
 


### PR DESCRIPTION
Without this, the pip commands run in the virtualenv of
edx-cookiecutters itself, which causes a very difficult-to-diagnose
flaky test result on Travis CI, possibly involving Travis's pip cache.

Adds `virtualenv` to cookiecutter's dependencies.

Clearing the environment for the subprocess call is essential --
otherwise, the PATH and VIRTUALENV environment variables of the test
runner will leak through to the subprocess.

The virtualenv is created and destroyed again just for the upgrade
command, since it interferes with other tests. For instance, the
pylint and isort checks will try to lint site-packages in the
virtualenv. To fix this we'll want to call a `make quality` command in
the baked project rather than parastically relying on the packages and
configurations in the cookiecutters project, but that's out of scope
for this fix. See ARCHBOM-1593 for future improvements.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)