### PR TITLE
Rename the docs requirement file.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Change Log
 ..
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
+2020-11-06
+----------
+
+Fixed
+~~~~~
+
+* Fix Read the Docs config to point to the correct config file.
+  ``requirements/docs.txt`` should be ``requirements/doc.txt``
 
 2020-11-05
 ----------

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/.readthedocs.yml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/.readthedocs.yml
@@ -12,4 +12,4 @@ sphinx:
 python:
   version: 3.5
   install:
-    - requirements: requirements/docs.txt
+    - requirements: requirements/doc.txt


### PR DESCRIPTION
Rename it from `doc.{in,txt}` to `docs.{in,txt}`.  This minor change should reduce some
work when setting up Read the Docs(RTD) for a new repo because RTD by default looks for
`requirements/docs.txt`.  By making `requirements/docs.txt` our default file, users don't
need to go fix this after the fact that in their RTD configs.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed
