### PR TITLE
ARCHBOM-1598: Drop Python versions below 3.8 and Django below 2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Change Log
 ..
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
+
+2020-11-06
+----------
+
+Changed
+~~~~~~~
+
+* All projects (including top level) use Python 3.8 and Django 2.2
+
 2020-11-06
 ----------
 

--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,4 @@ test: ## run tests on every supported Python version
 	tox
 
 validate: ## run tests and quality checks
-	tox -e quality,py35,py38
-	
+	tox -e quality,py38

--- a/cookiecutter-django-app/Makefile
+++ b/cookiecutter-django-app/Makefile
@@ -27,7 +27,7 @@ test: ## run tests on every supported Python version
 	tox
 
 validate: ## run tests and quality checks
-	tox -e quality,py35,py38
+	tox -e quality,py38
 
 watch: bake ## generate project using defaults and watch for changes
 	watchmedo shell-command -p '*.*' -c 'make bake -e BAKE_OPTIONS=$(BAKE_OPTIONS)' -W -R -D \{{cookiecutter.repo_name}}/

--- a/cookiecutter-django-app/README.rst
+++ b/cookiecutter-django-app/README.rst
@@ -54,7 +54,7 @@ Enter the project and take a look around::
     $ ls
 
 Generate a virtualenv and generate requirements files with dependencies
-pinned to current versions (make sure you're using pip 9.0.2+ and Python 3.6)::
+pinned to current versions (make sure you're using pip 9.0.2+ and Python 3.8)::
 
     $ mkvirtualenv Blogging-for-humans
     $ make upgrade

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/.travis.yml
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/.travis.yml
@@ -8,7 +8,6 @@
 language: python
 
 python:
-  - 3.5
   - 3.8
 
 env:
@@ -17,11 +16,11 @@ env:
 
 matrix:
   include:
-    - python: 3.5
+    - python: 3.8
       env: TOXENV=quality
-    - python: 3.5
+    - python: 3.8
       env: TOXENV=docs
-    - python: 3.5
+    - python: 3.8
       env: TOXENV=pii_check
 
 cache:

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/conf.py
@@ -472,8 +472,8 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.6', None),
-    'django': ('https://docs.djangoproject.com/en/1.11/', 'https://docs.djangoproject.com/en/1.11/_objects/'),
+    'python': ('https://docs.python.org/3.8', None),
+    'django': ('https://docs.djangoproject.com/en/2.2/', 'https://docs.djangoproject.com/en/2.2/_objects/'),
     'model_utils': ('https://django-model-utils.readthedocs.io/en/latest/', None),
 }
 

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/requirements/base.in
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/requirements/base.in
@@ -1,7 +1,7 @@
 # Core requirements for using this application
 -c constraints.txt
 
-Django>=1.11              # Web application framework
+Django>=2.2              # Web application framework
 {% if cookiecutter.models != "Comma-separated list of models" -%}
 django-model-utils        # Provides TimeStampedModel abstract base class
 {%- endif %}

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py38}-django{22,30}
+envlist = py38-django{22,30}
 
 [doc8]
 ; D001 = Line too long

--- a/cookiecutter-django-ida/Makefile
+++ b/cookiecutter-django-ida/Makefile
@@ -9,7 +9,7 @@ test: clean
 	# Create a new project with the default values
 	cookiecutter . --no-input
 
-	virtualenv -p python3.6 repo_name/.venv
+	virtualenv -p python3.8 repo_name/.venv
 
 	# Generate requirement pins, install them, and execute the project's tests
 	. repo_name/.venv/bin/activate && cd repo_name && pip install -U pip==19.3.1 wheel && make upgrade validation_requirements

--- a/cookiecutter-django-ida/README.rst
+++ b/cookiecutter-django-ida/README.rst
@@ -5,11 +5,11 @@ A cookiecutter_ template for edX Django projects.
 
 .. _cookiecutter: https://cookiecutter.readthedocs.org/en/latest/index.html
 
-**This template produces a Python 3.5 project.**
+**This template produces a Python 3.8 project.**
 
 This cookiecutter template is intended for new edX independently deployable apps (IDAs). It includes the following packages:
 
-* Django 1.11.x
+* Django 2.2
 * Django REST Framework
 * Django Waffle
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/.travis.yml
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/.travis.yml
@@ -1,9 +1,6 @@
 language: python
 
 python:
-  - 3.5
-  - 3.6
-  - 3.7
   - 3.8
 
 sudo: false

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
@@ -20,7 +20,7 @@ MAINTAINER devops@edx.org
 RUN apt-get update && apt-get -qy install --no-install-recommends \
  language-pack-en \
  locales \
- python3.5 \
+ python3.8 \
  python3-pip \
  libmysqlclient-dev \
  libssl-dev \

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/requirements/base.in
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/requirements/base.in
@@ -1,7 +1,7 @@
 # Core requirements for using this application
 -c constraints.txt
 
-Django>=1.11          # Web application framework
+Django>=2.2          # Web application framework
 django-cors-headers
 django-extensions
 django-rest-swagger

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/base.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/base.py
@@ -85,7 +85,7 @@ ROOT_URLCONF = '{{cookiecutter.repo_name}}.urls'
 WSGI_APPLICATION = '{{cookiecutter.repo_name}}.wsgi.application'
 
 # Database
-# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
+# https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 # Set this value in the environment-specific files (e.g. local.py, production.py, test.py)
 DATABASES = {
     'default': {
@@ -138,7 +138,7 @@ STATICFILES_DIRS = (
 )
 
 # TEMPLATE CONFIGURATION
-# See: https://docs.djangoproject.com/en/1.11/ref/settings/#templates
+# See: https://docs.djangoproject.com/en/2.2/ref/settings/#templates
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/urls.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/urls.py
@@ -1,6 +1,6 @@
 """{{ cookiecutter.repo_name }} URL Configuration
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.11/topics/http/urls/
+    https://docs.djangoproject.com/en/2.2/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/wsgi.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for {{cookiecutter.repo_name}}.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/2.2/howto/deployment/wsgi/
 """
 import os
 from os.path import abspath, dirname

--- a/cookiecutter-python-library/README.rst
+++ b/cookiecutter-python-library/README.rst
@@ -5,7 +5,7 @@ A cookiecutter_ template for edX python projects. For django related cookiecutte
 
 .. _cookiecutter: https://cookiecutter.readthedocs.org/en/latest/index.html
 
-**This template produces a Python 3.5 project.**
+**This template produces a Python 3.8 project.**
 
 This cookiecutter template is intended for new edX python libraries.
 

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/README.rst
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/README.rst
@@ -71,7 +71,7 @@ These catalogs can be created by running::
 The previous command will create the necessary ``.po`` files under
 ``{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/en/LC_MESSAGES/text.po``.
 The ``text.po`` file is created from the ``django-partial.po`` file created by
-``django-admin makemessages`` (`makemessages documentation <https://docs.djangoproject.com/en/1.11/topics/i18n/translation/#message-files>`_),
+``django-admin makemessages`` (`makemessages documentation <https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#message-files>`_),
 this is why you will not see a ``django-partial.po`` file.
 
 3. Create language specific translations
@@ -114,7 +114,7 @@ Once translations are in place, use the following Make target to compile the tra
     $ make compile_translations
 
 The previous command will compile ``.po`` files using
-``django-admin compilemessages`` (`compilemessages documentation <https://docs.djangoproject.com/en/1.11/topics/i18n/translation/#compiling-message-files>`_).
+``django-admin compilemessages`` (`compilemessages documentation <https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#compiling-message-files>`_).
 After compiling the ``.po`` file(s), ``django-statici18n`` is used to create language specific catalogs. See
 ``django-statici18n`` `documentation <https://django-statici18n.readthedocs.io/en/latest/>`_ for more information.
 
@@ -147,5 +147,5 @@ If there are any errors compiling ``.po`` files run the following command to val
     $ make validate
 
 See `django's i18n troubleshooting documentation
-<https://docs.djangoproject.com/en/1.11/topics/i18n/translation/#troubleshooting-ugettext-incorrectly-detects-python-format-in-strings-with-percent-signs>`_
+<https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#troubleshooting-gettext-incorrectly-detects-python-format-in-strings-with-percent-signs>`_
 for more information.

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/settings.py
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/settings.py
@@ -1,9 +1,9 @@
 """
 Django settings for {{cookiecutter.package_name}} project.
 For more information on this file, see
-https://docs.djangoproject.com/en/1.11/topics/settings/
+https://docs.djangoproject.com/en/2.2/topics/settings/
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.11/ref/settings/
+https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 import os
 
@@ -17,7 +17,7 @@ INSTALLED_APPS = (
 )
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.11/topics/i18n/
+# https://docs.djangoproject.com/en/2.2/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 
@@ -31,7 +31,7 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.11/howto/static-files/
+# https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/.readthedocs.yml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/.readthedocs.yml
@@ -10,6 +10,6 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.5
+  version: 3.8
   install:
     - requirements: requirements/doc.txt

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/.travis.yml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/.travis.yml
@@ -8,20 +8,17 @@
 language: python
 
 python:
-  - 3.5
   - 3.8
 
 matrix:
   include:
-    - python: 3.5
-      env: TOXENV=py35
     - python: 3.8
       env: TOXENV=py38
-    - python: 3.5
+    - python: 3.8
       env: TOXENV=quality
-    - python: 3.5
+    - python: 3.8
       env: TOXENV=docs
-    - python: 3.5
+    - python: 3.8
       env: TOXENV=pii_check
 
 cache:

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
@@ -472,7 +472,7 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.6', None),
+    'python': ('https://docs.python.org/3.8', None),
 }
 
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -95,7 +95,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=load_requirements('requirements/base.in'),
-    python_requires=">=3.5",
+    python_requires=">=3.8",
 {%- if cookiecutter.open_source_license in license_classifiers %}
     license="{{ cookiecutter.open_source_license }}",
 {%- endif %}
@@ -105,9 +105,6 @@ setup(
         'Development Status :: 3 - Alpha',
         {%- if cookiecutter.requires_django == "yes" %}
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         {%- endif %}
         'Intended Audience :: Developers',
@@ -120,7 +117,6 @@ setup(
         {%- endif %}
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.8',
     ],
 {%- if cookiecutter.setup_py_keyword_args != "None" %}

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/tox.ini
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38}
+envlist = py{38}
 
 [doc8]
 ; D001 = Line too long


### PR DESCRIPTION
**Description:**

The upgrade to Django 2.2 is long since complete, and the upgrade of
libraries and IDAs to Python 3.8 is wrapping up -- all new repos should
be on 3.8.

**JIRA:**

[ARCHBOM-1598](https://openedx.atlassian.net/browse/ARCHBOM-1598)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
