### PR TITLE
Git-ignore top-level /venv/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ pip-log.txt
 coverage.xml
 htmlcov/
 
-
+# Virtual environment
+/venv/
 
 # The Silver Searcher
 .agignore

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/.gitignore
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/.gitignore
@@ -32,7 +32,8 @@ pip-log.txt
 coverage.xml
 htmlcov/
 
-
+# Virtual environment
+/venv/
 
 # The Silver Searcher
 .agignore


### PR DESCRIPTION
I'm tired of accidentally committing my virtual
environment.

Change applies to cookiecutters for XBlocks, Python
packages, and Django apps, all of which are usually
developed using a virtual envs. Omitting IDAs because
they usually use Docker instead.
