### PR TITLE
Add the ability to trigger Github action manually 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches:
+      - '**'
+  workflow_dispatch:
+    branches:
+      - '**'
 
 
 jobs:


### PR DESCRIPTION
and run on PRs created against any branch.

This should allow us to run newly added Github Action on old PRs that are stuck waiting for `required` Github action checks to pass before we can merge those.