### PR TITLE
feat: Adding "edit on github" button to new project's ReadTheDocs

### DIFF
--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
@@ -107,7 +107,6 @@ html_context = {
     "conf_py_path": "/docs/", # Path in the checkout to the docs root
 }
 
-
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
@@ -100,11 +100,11 @@ documentation_title = "{project_title}".format(project_title=project_title)
 
 # Set display_github to False if you don't want "edit on Github" button
 html_context = {
-    "display_github": True, # Integrate GitHub
-    "github_user": "edx", # Username
-    "github_repo": '{{ cookiecutter.project_name }}', # Repo name
-    "github_version": "master", # Version
-    "conf_py_path": "/docs/", # Path in the checkout to the docs root
+    "display_github": True,  # Integrate GitHub
+    "github_user": "edx",  # Username
+    "github_repo": '{{ cookiecutter.project_name }}',  # Repo name
+    "github_version": "master",  # Version
+    "conf_py_path": "/docs/",  # Path in the checkout to the docs root
 }
 
 # The version info for the project you're documenting, acts as replacement for

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
@@ -97,6 +97,17 @@ author = edx_theme.AUTHOR
 project_title = '{{ cookiecutter.project_name }}'
 documentation_title = "{project_title}".format(project_title=project_title)
 
+
+# Set display_github to False if you don't want "edit on Github" button
+html_context = {
+    "display_github": True, # Integrate GitHub
+    "github_user": "edx", # Username
+    "github_repo": '{{ cookiecutter.project_name }}', # Repo name
+    "github_version": "master", # Version
+    "conf_py_path": "/docs/", # Path in the checkout to the docs root
+}
+
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.


### PR DESCRIPTION
This is to make it easier to modify docs if they are wrong or outdated. This has been tested in Devstack's RTD: https://edx.readthedocs.io/projects/open-edx-devstack/en/latest/

Docs for this in: https://github.com/edx/edx-sphinx-theme/pull/97


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
