### PR TITLE
ARCHBOM-1721: fix: django package docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Fixed
 
 * Fixed django module documentation by using proper django settings.
 
+Added
+~~~~~
+
+* Added "Edit on Github" button to new project's ReadTheDocs.
+
 2020-11-25
 ----------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2021-04-05
+----------
+
+Fixed
+~~~~~
+
+* Fixed django module documentation by using proper django settings.
+
 2020-11-25
 ----------
 

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/conf.py
@@ -20,7 +20,6 @@ from subprocess import check_call
 
 import edx_theme
 from django import setup as django_setup
-from django.conf import settings
 
 
 def get_version(*file_paths):
@@ -41,7 +40,7 @@ sys.path.append(REPO_ROOT)
 VERSION = get_version('../{{ cookiecutter.app_name }}', '__init__.py')
 
 # Configure Django for autodoc usage
-settings.configure()
+os.environ['DJANGO_SETTINGS_MODULE'] = 'test_settings'
 django_setup()
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
**Description:**

The proper Django Settings were not getting used when building
docs, which caused certain modules to not build in the package
docs.

Fix taken from this PR:
https://github.com/edx/edx-toggles/pull/126

Note: Also adds a changelog entry for [an earlier commit](https://github.com/edx/edx-cookiecutters/commit/cf0bd692744f72914066a414c0554e9c73c793bd).

**JIRA:**

ARCHBOM-1721

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
