### PR TITLE
Upgrade IDA cookiecutter Dockerfile to use newer Ubuntu

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,24 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2021-06-01
+----------
+
+Fixed
+~~~~~
+
+* Django-IDA Dockerfiles
+
+Added
+~~~~~
+
+* Testing Dockerfiles into `make test` for Django-IDA
+
+Changed
+~~~~~~~
+
+* Django-IDA Dockerfile now uses ubuntu focal
+
 2021-04-05
 ----------
 

--- a/cookiecutter-django-ida/Makefile
+++ b/cookiecutter-django-ida/Makefile
@@ -19,6 +19,9 @@ test: clean
 	# Ensure translations can be compiled
 	. repo_name/.venv/bin/activate && cd repo_name && make fake_translations
 
+	# Ensure docker can build a container from this
+	cd repo_name && docker build . --target app
+
 	# Ensure documentation can be compiled
 	. repo_name/.venv/bin/activate && cd repo_name && make doc_requirements
 	. repo_name/.venv/bin/activate && cd repo_name/docs && make html

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:bionic as app
-MAINTAINER devops@edx.org
+FROM ubuntu:focal as app
+MAINTAINER sre@edx.org
 
 
 # Packages installed:
@@ -11,10 +11,14 @@ MAINTAINER devops@edx.org
 
 # python3-pip; install pip to install application requirements.txt files
 
-# libssl-dev; # mysqlclient wont install without this.
-
 # libmysqlclient-dev; to install header files needed to use native C implementation for
 # MySQL-python for performance gains.
+
+# libssl-dev; # mysqlclient wont install without this.
+
+# python3-dev; to install header files for python extensions; much wheel-building depends on this
+
+# gcc; for compiling python extensions distributed with python packages like mysql-client
 
 # If you add a package here please include a comment above describing what it is used for
 RUN apt-get update && apt-get -qy install --no-install-recommends \
@@ -24,11 +28,14 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  python3-pip \
  libmysqlclient-dev \
  libssl-dev \
- python3-dev && \
- pip3 install --upgrade pip setuptools && \
- rm -rf /var/lib/apt/lists/*
+ python3-dev \
+ gcc
 
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
+
+RUN pip install --upgrade pip setuptools
+# delete apt package lists because we do not need them inflating our image
+RUN rm -rf /var/lib/apt/lists/*
+
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN locale-gen en_US.UTF-8
@@ -47,7 +54,7 @@ WORKDIR /edx/app/{{cookiecutter.repo_name}}
 COPY requirements/production.txt /edx/app/{{cookiecutter.repo_name}}/requirements/production.txt
 
 # Dependencies are installed as root so they cannot be modified by the application user.
-RUN pip3 install -r requirements/production.txt
+RUN pip install -r requirements/production.txt
 
 RUN mkdir -p /edx/var/log
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/manage.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/manage.py
@@ -12,18 +12,18 @@ if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{cookiecutter.repo_name}}.settings.local')
     sys.path.append(PWD)
     try:
-        from django.core.management import execute_from_command_line  # pylint: disable=wrong-import-position
+        from django.core.management import execute_from_command_line
     except ImportError:
         # The above import may fail for some other reason. Ensure that the
         # issue is really that Django is missing to avoid masking other
         # exceptions on Python 2.
         try:
-            import django  # pylint: disable=unused-import, wrong-import-position
+            import django  # pylint: disable=unused-import
         except ImportError:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "
                 "available on your PYTHONPATH environment variable? Did you "
                 "forget to activate a virtual environment?"
-            )
+            ) from None
         raise
     execute_from_command_line(sys.argv)

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/requirements/constraints.txt
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/requirements/constraints.txt
@@ -10,3 +10,13 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+
+## begin copied from edx-platform as of https://github.com/edx/edx-platform/blob/1fb0ed58bb4b55a714b6bd9a29ac6ae1a47abbf7/requirements/constraints.txt#L21
+# cryptography 3.3 has dropped python3.5 support.
+cryptography<3.3
+
+# PYJWT[crypto]==2.0.1 requires cryptography>=3.3.1
+PyJWT[crypto]<2.0.0
+# social-auth-core>=4.0.0 requires PYJWT>=2.0.0
+social-auth-core<4.0.0
+

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/setup.cfg
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/setup.cfg
@@ -1,0 +1,6 @@
+[isort]
+indent='    '
+line_length=120
+multi_line_output=3
+skip=
+    migrations

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
@@ -1,0 +1,4 @@
+"""
+{{cookiecutter.repo_name}} module
+"""
+__version__ = '1.0.0'

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/api/urls.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/api/urls.py
@@ -8,7 +8,6 @@ from django.conf.urls import include, url
 
 from {{cookiecutter.repo_name}}.apps.api.v1 import urls as v1_urls
 
-
 app_name = 'api'
 urlpatterns = [
     url(r'^v1/', include(v1_urls)),

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/core/tests/test_context_processors.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/core/tests/test_context_processors.py
@@ -4,7 +4,6 @@ from django.test import RequestFactory, TestCase, override_settings
 
 from {{cookiecutter.repo_name}}.apps.core.context_processors import core
 
-
 PLATFORM_NAME = 'Test Platform'
 
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/core/tests/test_views.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/core/tests/test_views.py
@@ -10,7 +10,6 @@ from django.urls import reverse
 
 from {{cookiecutter.repo_name}}.apps.core.constants import Status
 
-
 User = get_user_model()
 
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/core/views.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/apps/core/views.py
@@ -12,7 +12,6 @@ from edx_django_utils.monitoring import ignore_transaction
 
 from {{cookiecutter.repo_name}}.apps.core.constants import Status
 
-
 logger = logging.getLogger(__name__)
 User = get_user_model()
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/docker_gunicorn_configuration.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/docker_gunicorn_configuration.py
@@ -23,8 +23,8 @@ def close_all_caches():
     """
     # We do this in a way that is safe for 1.4 and 1.8 while we still have some
     # 1.4 installations.
-    from django.conf import settings
-    from django.core import cache as django_cache
+    from django.conf import settings  # lint-amnesty, pylint: disable=import-outside-toplevel
+    from django.core import cache as django_cache  # lint-amnesty, pylint: disable=import-outside-toplevel
     if hasattr(django_cache, 'caches'):
         get_cache = django_cache.caches.__getitem__
     else:
@@ -50,7 +50,7 @@ def post_fork(server, worker):  # pylint: disable=unused-argument
 
 def when_ready(server):  # pylint: disable=unused-argument
     """When running in debug mode, run Django's `check` to better match what `manage.py runserver` does"""
-    from django.conf import settings
-    from django.core.management import call_command
+    from django.conf import settings  # lint-amnesty, pylint: disable=import-outside-toplevel
+    from django.core.management import call_command  # lint-amnesty, pylint: disable=import-outside-toplevel
     if settings.DEBUG:
         call_command("check")

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
@@ -1,9 +1,9 @@
 from os import environ
+
 import yaml
 
 from {{cookiecutter.repo_name}}.settings.base import *
 from {{cookiecutter.repo_name}}.settings.utils import get_env_setting
-
 
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/test.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/test.py
@@ -2,7 +2,6 @@ import os
 
 from {{cookiecutter.repo_name}}.settings.base import *
 
-
 # IN-MEMORY TEST DATABASE
 DATABASES = {
     'default': {

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/urls.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/urls.py
@@ -24,7 +24,6 @@ from rest_framework_swagger.views import get_swagger_view
 from {{cookiecutter.repo_name}}.apps.api import urls as api_urls
 from {{cookiecutter.repo_name}}.apps.core import views as core_views
 
-
 admin.autodiscover()
 
 urlpatterns = oauth2_urlpatterns + [

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/wsgi.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/wsgi.py
@@ -14,7 +14,6 @@ from django.conf import settings
 from django.contrib.staticfiles.handlers import StaticFilesHandler
 from django.core.wsgi import get_wsgi_application
 
-
 SITE_ROOT = dirname(dirname(abspath(__file__)))
 path.append(SITE_ROOT)
 


### PR DESCRIPTION
**Description:**

Focal! Everywhere! Also dockerfiles that work, let's do that.

Haven't fixed everything downstream of `make test` in that cookiecutter, but getting some things done.

I was originally motivated by the fact that focal newly doesn't require a separate step to make sure that pip3 is the pip being used, since the python3-pip package was recently updated to provide the executable in `/etc/bin`.

**JIRA:**

lol no

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
