### PR TITLE
feat: add commitlint.yml to all three cookiecutters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,15 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2021-10-27
+----------
+
+Added
+~~~~~
+
+* Added GitHub Actions to the python-template cookiecutter so that all 
+  cookiecutters will make repos that check for conventional commits.
+
 2021-10-01
 ----------
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/.github/workflows/commitlint.yml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/.github/workflows/commitlint.yml
@@ -1,0 +1,10 @@
+# Run commitlint on the commit messages in a pull request.
+
+name: Lint Commit Messages
+
+on:
+  - pull_request
+
+jobs:
+  commitlint:
+    uses: edx/.github/.github/workflows/commitlint.yml@master


### PR DESCRIPTION
**Description:**

This adds our new common GitHub Action that checks commit messages for conformance to our conventional commit standards. All three cookiecutters now have it so that new repos will run the checks.

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
