### PR TITLE
feat: switched default branch to main

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Python CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     branches:
       - '**'

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/.github/workflows/docker-publish.yml
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Push Docker Images
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/

--- a/docs/decisions/0005-cookiecutter-default-branch.rst
+++ b/docs/decisions/0005-cookiecutter-default-branch.rst
@@ -13,6 +13,7 @@ Context
 Github now sets default branch of each new repository to main. And the software industry as a whole has been moving towards default branch name flexibility and away from naming the default branch "master".
 
 There are number of places in edx-cookiecutters where we make assumption about the name of the default branch. Until now, we assumed that name was "master".
+
 Decision
 --------
 

--- a/docs/decisions/0005-cookiecutter-default-branch.rst
+++ b/docs/decisions/0005-cookiecutter-default-branch.rst
@@ -25,7 +25,6 @@ As an additional nudge in this direction, it was decided not to provide an optio
 Consequences
 ------------
 
-
 - Using "main" for a new repository for a library should be safe at this time, but using it for a new IDA may required additional changes to support it.
 
 - Much of our tooling may need to be updated to handle both "main" and "master" for some transitional period.

--- a/docs/decisions/0005-cookiecutter-default-branch.rst
+++ b/docs/decisions/0005-cookiecutter-default-branch.rst
@@ -20,7 +20,14 @@ Decision
 
 edx-cookiecutters tooling will assume new repositories created using the cookiecutters will have the default name of "main".
 
+As an additional nudge in this direction, it was decided not to provide an option that defaults to "main". If you need to use "master", you will need to manually rename references.
+
 Consequences
 ------------
 
-Lots of tooling in Open edX ecosystem assumes the default branch has the name "master". This decision might result in necessary changes to our tooling to accommodate multiple default branch names.
+
+- Using "main" for a new repository for a library should be safe at this time, but using it for a new IDA may required additional changes to support it.
+
+- Much of our tooling may need to be updated to handle both "main" and "master" for some transitional period.
+
+  + Continuing to use "master" for a new repository would require manual changes after using the cookie-cutter.

--- a/docs/decisions/0005-cookiecutter-default-branch.rst
+++ b/docs/decisions/0005-cookiecutter-default-branch.rst
@@ -14,6 +14,7 @@ Github now sets default branch of each new repository to main. And the software 
 
 There are number of places in edx-cookiecutters where we make assumption about the name of the default branch. Until now, we assumed that name was "master".
 
+
 Decision
 --------
 

--- a/docs/decisions/0005-cookiecutter-default-branch.rst
+++ b/docs/decisions/0005-cookiecutter-default-branch.rst
@@ -12,11 +12,11 @@ Context
 
 Github now sets default branch of each new repository to main. And the software industry as a whole has been moving towards default branch name flexibility and away from naming the default branch "master".
 
-There are number of places in edx-cookiecutters where we make assumption about the name of the default branch. Until now, we assumed that name is "master".
+There are number of places in edx-cookiecutters where we make assumption about the name of the default branch. Until now, we assumed that name was "master".
 Decision
 --------
 
-The name of the default branch will be assumed to be "main" by edx-cookiecutter tooling.
+edx-cookiecutters tooling will assuming new repositories created using the cookiecutters will have the default name of "main".
 
 Consequences
 ------------

--- a/docs/decisions/0005-cookiecutter-default-branch.rst
+++ b/docs/decisions/0005-cookiecutter-default-branch.rst
@@ -12,10 +12,11 @@ Context
 
 Github now sets default branch of each new repository to main. And the software industry as a whole has been moving towards default branch name flexibility and away from naming the default branch "master".
 
+There are number of places in edx-cookiecutters where we make assumption about the name of the default branch. Until now, we assumed that name is "master".
 Decision
 --------
 
-It as decided to change name of default branches to "main" for all new repositories created with cookiecutters.
+The name of the default branch will be assumed to be "main" by edx-cookiecutter tooling.
 
 Consequences
 ------------

--- a/docs/decisions/0005-cookiecutter-default-branch.rst
+++ b/docs/decisions/0005-cookiecutter-default-branch.rst
@@ -29,4 +29,4 @@ Consequences
 
 - Much of our tooling may need to be updated to handle both "main" and "master" for some transitional period.
 
-  + Continuing to use "master" for a new repository would require manual changes after using the cookie-cutter.
+  - Continuing to use "master" for a new repository would require manual changes after using the cookie-cutter.

--- a/docs/decisions/0005-cookiecutter-default-branch.rst
+++ b/docs/decisions/0005-cookiecutter-default-branch.rst
@@ -1,0 +1,23 @@
+Cookiecutter default branch
+===========================
+
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+Github now sets default branch of each new repository to main. And the software industry as a whole has been moving towards default branch name flexibility and away from naming the default branch "master".
+
+Decision
+--------
+
+It as decided to change name of default branches to "main" for all new repositories created with cookiecutters.
+
+Consequences
+------------
+
+Lots of tooling in Open edX ecosystem assumes the default branch has the name "master". This decision might result in necessary changes to our tooling to accommodate multiple default branch names.

--- a/docs/decisions/0005-cookiecutter-default-branch.rst
+++ b/docs/decisions/0005-cookiecutter-default-branch.rst
@@ -18,7 +18,7 @@ There are number of places in edx-cookiecutters where we make assumption about t
 Decision
 --------
 
-edx-cookiecutters tooling will assuming new repositories created using the cookiecutters will have the default name of "main".
+edx-cookiecutters tooling will assume new repositories created using the cookiecutters will have the default name of "main".
 
 Consequences
 ------------

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/.github/workflows/ci.yml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Python CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     branches:
       - '**'

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -46,7 +46,7 @@ Every time you develop something in this repo
   workon {{ cookiecutter.repo_name }}
 
   # Grab the latest code
-  git checkout master
+  git checkout main
   git pull
 
   # Install/update the dev requirements
@@ -117,12 +117,12 @@ For more information about these options, see the `Getting Help`_ page.
     :target: https://pypi.python.org/pypi/{{ cookiecutter.repo_name }}/
     :alt: PyPI
 
-.. |ci-badge| image:: https://github.com/edx/{{ cookiecutter.repo_name }}/workflows/Python%20CI/badge.svg?branch=master
+.. |ci-badge| image:: https://github.com/edx/{{ cookiecutter.repo_name }}/workflows/Python%20CI/badge.svg?branch=main
     :target: https://github.com/edx/{{ cookiecutter.repo_name }}/actions
     :alt: CI
 
-.. |codecov-badge| image:: https://codecov.io/github/edx/{{ cookiecutter.repo_name }}/coverage.svg?branch=master
-    :target: https://codecov.io/github/edx/{{ cookiecutter.repo_name }}?branch=master
+.. |codecov-badge| image:: https://codecov.io/github/edx/{{ cookiecutter.repo_name }}/coverage.svg?branch=main
+    :target: https://codecov.io/github/edx/{{ cookiecutter.repo_name }}?branch=main
     :alt: Codecov
 
 .. |doc-badge| image:: https://readthedocs.org/projects/{{ cookiecutter.repo_name }}/badge/?version=latest
@@ -134,5 +134,5 @@ For more information about these options, see the `Getting Help`_ page.
     :alt: Supported Python versions
 
 .. |license-badge| image:: https://img.shields.io/github/license/edx/{{ cookiecutter.repo_name }}.svg
-    :target: https://github.com/edx/{{ cookiecutter.repo_name }}/blob/master/LICENSE.txt
+    :target: https://github.com/edx/{{ cookiecutter.repo_name }}/blob/main/LICENSE.txt
     :alt: License

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
@@ -101,7 +101,7 @@ html_context = {
     "display_github": True,  # Integrate GitHub
     "github_user": "edx",  # Username
     "github_repo": '{{ cookiecutter.project_name }}',  # Repo name
-    "github_version": "master",  # Version
+    "github_version": "main",  # Version
     "conf_py_path": "/docs/",  # Path in the checkout to the docs root
 }
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/openedx.yaml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/openedx.yaml
@@ -21,4 +21,4 @@ openedx-release:
     #   https://open-edx-proposals.readthedocs.io/en/latest/oep-0010-proc-openedx-releases.html
     # The FAQ might also be helpful: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1331268879/Open+edX+Release+FAQ
     maybe: true   # Delete this "maybe" line when you have decided about Open edX inclusion.
-    ref: master
+    ref: main


### PR DESCRIPTION
After this change, cookiecutter will produce repositories with
assumption the default branch in main

