### PR TITLE
feat: make update_setup_py.sh idempotent

### DIFF
--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -76,7 +76,8 @@ def load_requirements(*requirements_paths):
                     add_version_constraint_or_raise(line, requirements, False)
 
     # process back into list of pkg><=constraints strings
-    return [f'{pkg}{version or ""}' for (pkg, version) in sorted(requirements.items())]
+    constrained_requirements = [f'{pkg}{version or ""}' for (pkg, version) in sorted(requirements.items())]
+    return constrained_requirements
 
 
 def is_requirement(line):


### PR DESCRIPTION
**Description:**

- move SEMGREP comment inside method so it doesn't get added anew every time the script is run (semgrep can't match comments)
- small refactor of the end of load_requirements to address a weird semgrep issue: https://github.com/returntocorp/semgrep/issues/4221
- clarify what is being printed in the PR message
- add a newline to MANIFEST.in if needed
- only add to MANIFEST.in if it doesn't already have requirements/constraints.txt in it

**JIRA:**

[ARCHBOM-1772](https://openedx.atlassian.net/browse/ARCHBOM-1772)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed