### PR TITLE
build: add dependabot config template

### DIFF
--- a/python-template/{{cookiecutter.placeholder_repo_name}}/.github/dependabot.yml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+    # Adding new check for github-actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+        interval: "weekly"
+    # reviewers:
+    #   - "openedx/arbi-bom"


### PR DESCRIPTION
## Description
- PR created under the suggestion on the issue https://github.com/edx/edx-arch-experiments/issues/425. 
- Added `dependabot.yml` config templates in the `django-app`, `django-ida` and `xblock` cookiecutter templates.