### PR TITLE
docs: Update link to i18n guide

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/internationalization.rst
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/internationalization.rst
@@ -8,7 +8,7 @@ this choice.
 
 Follow the `internationalization coding guidelines`_ in the edX Developer's Guide when developing new features.
 
-.. _internationalization coding guidelines: https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
+.. _internationalization coding guidelines: https://docs.openedx.org/en/latest/developers/references/developer_guide/internationalization/i18n.html
 
 Updating Translations
 *********************

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/docs/internationalization.rst
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/docs/internationalization.rst
@@ -8,7 +8,7 @@ this choice.
 
 Follow the `internationalization coding guidelines`_ in the edX Developer's Guide when developing new features.
 
-.. _internationalization coding guidelines: https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
+.. _internationalization coding guidelines: https://docs.openedx.org/en/latest/developers/references/developer_guide/internationalization/i18n.html
 
 Updating Translations
 *********************

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/README.rst
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/README.rst
@@ -47,7 +47,7 @@ Mark translatable strings in python:
     # Translators: This comment will appear in the `.po` file.
     message = _("This will be marked.")
 
-See `edx-developer-guide <https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/internationalization/i18n.html#python-source-code>`__
+See `edx-developer-guide <https://docs.openedx.org/en/latest/developers/references/developer_guide/internationalization/i18n.html#python-source-code>`__
 for more information.
 
 You can also use ``gettext`` to mark strings in javascript:
@@ -57,7 +57,7 @@ You can also use ``gettext`` to mark strings in javascript:
     // Translators: This comment will appear in the `.po` file.
     var message = gettext("Custom message.");
 
-See `edx-developer-guide <https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/internationalization/i18n.html#javascript-files>`__
+See `edx-developer-guide <https://docs.openedx.org/en/latest/developers/references/developer_guide/internationalization/i18n.html#javascript-files>`__
 for more information.
 
 2. Run i18n tools to create Raw message catalogs

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/internationalization.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/internationalization.rst
@@ -8,7 +8,7 @@ this choice.
 
 Follow the `internationalization coding guidelines`_ in the edX Developer's Guide when developing new features.
 
-.. _internationalization coding guidelines: https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
+.. _internationalization coding guidelines: https://docs.openedx.org/en/latest/developers/references/developer_guide/internationalization/i18n.html
 
 Updating Translations
 *********************


### PR DESCRIPTION
The i18n Developer's Guide has moved to https://docs.openedx.org/en/latest/developers/references/developer_guide/internationalization/i18n.html

Ref: https://github.com/openedx/docs.openedx.org/issues/955
