### PR TITLE
fix: update ubuntu version in cookiecutter_ida

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,10 +3,10 @@ File configures pytest for this repo
 """
 
 
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(collection_path, config):
     """
     Pytest hook to determine if tests should be collected in `path`.
     """
-    if "{" in str(path) and "}" in str(path):
+    if "{" in str(collection_path) and "}" in str(collection_path):
         return True
     return None

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal AS app
+FROM ubuntu:jammy AS app
 
 ARG PYTHON_VERSION=3.12
 ENV TZ=UTC

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/requirements/pip-tools.txt
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/requirements/pip-tools.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-build==1.2.2.post1
+build==1.3.0
     # via pip-tools
-click==8.1.8
+click==8.3.1
     # via pip-tools
-packaging==24.2
+packaging==25.0
     # via build
-pip-tools==7.4.1
+pip-tools==7.5.2
     # via -r python-template/{{cookiecutter.placeholder_repo_name}}/requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/requirements/pip.txt
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.45.1
     # via -r python-template/{{cookiecutter.placeholder_repo_name}}/requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.0.1
+pip==25.3
     # via -r python-template/{{cookiecutter.placeholder_repo_name}}/requirements/pip.in
-setuptools==78.1.0
+setuptools==80.9.0
     # via -r python-template/{{cookiecutter.placeholder_repo_name}}/requirements/pip.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,21 +4,21 @@
 #
 #    make upgrade
 #
-arrow==1.3.0
+arrow==1.4.0
     # via cookiecutter
-astroid==3.3.9
+astroid==4.0.3
     # via
     #   pylint
     #   pylint-celery
 binaryornot==0.4.4
     # via cookiecutter
-certifi==2025.1.31
+certifi==2026.1.4
     # via requests
 chardet==5.2.0
     # via binaryornot
-charset-normalizer==3.4.1
+charset-normalizer==3.4.4
     # via requests
-click==8.1.8
+click==8.3.1
     # via
     #   click-log
     #   code-annotations
@@ -26,37 +26,35 @@ click==8.1.8
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via edx-lint
 cookiecutter==2.6.0
     # via -r requirements/base.in
-dill==0.3.9
+dill==0.4.0
     # via pylint
 edx-lint==5.6.0
     # via -r requirements/base.in
-idna==3.10
+idna==3.11
     # via requests
-isort==6.0.1
+isort==7.0.0
     # via pylint
 jinja2==3.1.6
     # via
     #   code-annotations
     #   cookiecutter
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-pbr==6.1.1
-    # via stevedore
-platformdirs==4.3.7
+platformdirs==4.5.1
     # via pylint
-pygments==2.19.1
+pygments==2.19.2
     # via rich
-pylint==3.3.6
+pylint==4.0.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -64,9 +62,9 @@ pylint==3.3.6
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
@@ -76,31 +74,25 @@ python-slugify==8.0.4
     # via
     #   code-annotations
     #   cookiecutter
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   code-annotations
     #   cookiecutter
-requests==2.32.3
+requests==2.32.5
     # via cookiecutter
-rich==14.0.0
+rich==14.2.0
     # via cookiecutter
 six==1.17.0
     # via
     #   edx-lint
     #   python-dateutil
-stevedore==5.4.1
+stevedore==5.6.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via pylint
-types-python-dateutil==2.9.0.20241206
+tzdata==2025.3
     # via arrow
-urllib3==2.2.3
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   requests
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==78.1.0
-    # via pbr
+urllib3==2.6.2
+    # via requests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,31 +4,31 @@
 #
 #    make upgrade
 #
-cachetools==5.5.2
+cachetools==6.2.4
     # via tox
 chardet==5.2.0
     # via tox
 colorama==0.4.6
     # via tox
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
-filelock==3.18.0
+filelock==3.20.2
     # via
     #   tox
     #   virtualenv
-packaging==24.2
+packaging==25.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.3.7
+platformdirs==4.5.1
     # via
     #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via tox
-pyproject-api==1.9.0
+pyproject-api==1.10.0
     # via tox
-tox==4.25.0
+tox==4.33.0
     # via -r requirements/ci.in
-virtualenv==20.29.3
+virtualenv==20.35.4
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,6 +18,3 @@ doc8<1.0.0
 pyobjc-core; sys_platform == 'darwin'
 pyobjc-framework-cocoa; sys_platform == 'darwin'
 pyobjc-framework-fsevents; sys_platform == 'darwin'
-
-# Temporary to Support the python 3.11 Upgrade
-backports.zoneinfo;python_version<"3.9"  # Newer versions have zoneinfo available in the standard library

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,15 +12,15 @@ alabaster==1.0.0
     # via
     #   -r requirements/test.txt
     #   sphinx
-arrow==1.3.0
+arrow==1.4.0
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-asgiref==3.8.1
+asgiref==3.11.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==3.3.9
+astroid==4.0.3
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -30,7 +30,7 @@ babel==2.17.0
     #   -r requirements/test.txt
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.13.3
+beautifulsoup4==4.14.3
     # via
     #   -r requirements/test.txt
     #   pydata-sphinx-theme
@@ -38,34 +38,30 @@ binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-build==1.2.2.post1
+build==1.3.0
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
     #   pip-tools
-cachetools==5.5.2
+cachetools==6.2.4
     # via
     #   -r requirements/ci.txt
     #   tox
-certifi==2025.1.31
+certifi==2026.1.4
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.17.1
-    # via
-    #   -r requirements/test.txt
-    #   cryptography
 chardet==5.2.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   binaryornot
     #   tox
-charset-normalizer==3.4.1
+charset-normalizer==3.4.4
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.1.8
+click==8.3.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
@@ -78,7 +74,7 @@ click-log==0.4.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -90,20 +86,16 @@ cookiecutter==2.6.0
     # via
     #   -r requirements/test.txt
     #   pytest-cookies
-cryptography==44.0.2
-    # via
-    #   -r requirements/test.txt
-    #   secretstorage
-dill==0.3.9
+dill==0.4.0
     # via
     #   -r requirements/test.txt
     #   pylint
-distlib==0.3.9
+distlib==0.4.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   virtualenv
-django==4.2.20
+django==5.2.9
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -125,7 +117,7 @@ docutils==0.21.2
     #   sphinx-rtd-theme
 edx-lint==5.6.0
     # via -r requirements/test.txt
-filelock==3.18.0
+filelock==3.20.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -135,7 +127,7 @@ id==1.5.0
     # via
     #   -r requirements/test.txt
     #   twine
-idna==3.10
+idna==3.11
     # via
     #   -r requirements/test.txt
     #   requests
@@ -143,11 +135,11 @@ imagesize==1.4.1
     # via
     #   -r requirements/test.txt
     #   sphinx
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==6.0.1
+isort==7.0.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -155,34 +147,29 @@ jaraco-classes==3.4.0
     # via
     #   -r requirements/test.txt
     #   keyring
-jaraco-context==6.0.1
+jaraco-context==6.0.2
     # via
     #   -r requirements/test.txt
     #   keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.4.0
     # via
     #   -r requirements/test.txt
     #   keyring
-jeepney==0.9.0
-    # via
-    #   -r requirements/test.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   cookiecutter
     #   sphinx
-keyring==25.6.0
+keyring==25.7.0
     # via
     #   -r requirements/test.txt
     #   twine
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via
     #   -r requirements/test.txt
     #   rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -194,16 +181,16 @@ mdurl==0.1.2
     # via
     #   -r requirements/test.txt
     #   markdown-it-py
-more-itertools==10.6.0
+more-itertools==10.8.0
     # via
     #   -r requirements/test.txt
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.2.21
+nh3==0.3.2
     # via
     #   -r requirements/test.txt
     #   readme-renderer
-packaging==24.2
+packaging==25.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -215,47 +202,40 @@ packaging==24.2
     #   sphinx
     #   tox
     #   twine
-pbr==6.1.1
-    # via
-    #   -r requirements/test.txt
-    #   stevedore
-pip-tools==7.4.1
+pip-tools==7.5.2
     # via -r requirements/pip-tools.txt
-platformdirs==4.3.7
+platformdirs==4.5.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   pylint
     #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   pytest
     #   tox
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via -r requirements/test.txt
-pycparser==2.22
-    # via
-    #   -r requirements/test.txt
-    #   cffi
 pydata-sphinx-theme==0.15.4
     # via
     #   -r requirements/test.txt
     #   sphinx-book-theme
 pydocstyle==6.3.0
     # via -r requirements/test.txt
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   -r requirements/test.txt
     #   accessible-pygments
     #   doc8
     #   pydata-sphinx-theme
+    #   pytest
     #   readme-renderer
     #   rich
     #   sphinx
-pylint==3.3.6
+pylint==4.0.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -266,16 +246,16 @@ pylint-celery==0.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pyproject-api==1.9.0
+pyproject-api==1.10.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -285,7 +265,7 @@ pyproject-hooks==1.2.0
     #   -r requirements/test.txt
     #   build
     #   pip-tools
-pytest==8.3.5
+pytest==9.0.2
     # via
     #   -r requirements/test.txt
     #   pytest-cookies
@@ -300,7 +280,7 @@ python-slugify==8.0.4
     #   -r requirements/test.txt
     #   code-annotations
     #   cookiecutter
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -309,7 +289,7 @@ readme-renderer==44.0
     # via
     #   -r requirements/test.txt
     #   twine
-requests==2.32.3
+requests==2.32.5
     # via
     #   -r requirements/test.txt
     #   cookiecutter
@@ -321,7 +301,7 @@ requests-toolbelt==1.0.0
     # via
     #   -r requirements/test.txt
     #   twine
-restructuredtext-lint==1.4.0
+restructuredtext-lint==2.0.2
     # via
     #   -r requirements/test.txt
     #   doc8
@@ -329,19 +309,19 @@ rfc3986==2.0.0
     # via
     #   -r requirements/test.txt
     #   twine
-rich==14.0.0
+rich==14.2.0
     # via
     #   -r requirements/test.txt
     #   cookiecutter
     #   twine
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
+    # via
+    #   -r requirements/test.txt
+    #   roman-numerals-py
+roman-numerals-py==4.1.0
     # via
     #   -r requirements/test.txt
     #   sphinx
-secretstorage==3.3.3
-    # via
-    #   -r requirements/test.txt
-    #   keyring
 sh==2.2.2
     # via -r requirements/test.txt
 six==1.17.0
@@ -349,12 +329,12 @@ six==1.17.0
     #   -r requirements/test.txt
     #   edx-lint
     #   python-dateutil
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via
     #   -r requirements/test.txt
     #   pydocstyle
     #   sphinx
-soupsieve==2.6
+soupsieve==2.8.1
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
@@ -397,11 +377,11 @@ sphinxcontrib-serializinghtml==2.0.0
     # via
     #   -r requirements/test.txt
     #   sphinx
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.4.1
+stevedore==5.6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -410,30 +390,29 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==4.25.0
+tox==4.33.0
     # via -r requirements/ci.txt
-twine==6.1.0
+twine==6.2.0
     # via -r requirements/test.txt
-types-python-dateutil==2.9.0.20241206
-    # via
-    #   -r requirements/test.txt
-    #   arrow
-typing-extensions==4.13.0
+typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
     #   pydata-sphinx-theme
-urllib3==2.2.3
+tzdata==2025.3
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/test.txt
+    #   arrow
+urllib3==2.6.2
+    # via
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.29.3
+virtualenv==20.35.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -444,12 +423,7 @@ wheel==0.45.1
     #   pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   pip-tools
-setuptools==78.1.0
-    # via
-    #   -r requirements/test.txt
-    #   pbr
-    #   pip-tools
+pip==25.3
+    # via pip-tools
+setuptools==80.9.0
+    # via pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-build==1.2.2.post1
+build==1.3.0
     # via pip-tools
-click==8.1.8
+click==8.3.1
     # via pip-tools
-packaging==24.2
+packaging==25.0
     # via build
-pip-tools==7.4.1
+pip-tools==7.5.2
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,9 +8,7 @@ wheel==0.45.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/pip.in
-setuptools==78.1.0
+pip==25.3
+    # via -r requirements/pip.in
+setuptools==80.9.0
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,13 +8,13 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==1.0.0
     # via sphinx
-arrow==1.3.0
+arrow==1.4.0
     # via
     #   -r requirements/base.txt
     #   cookiecutter
-asgiref==3.8.1
+asgiref==3.11.0
     # via django
-astroid==3.3.9
+astroid==4.0.3
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -23,29 +23,27 @@ babel==2.17.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.13.3
+beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
 binaryornot==0.4.4
     # via
     #   -r requirements/base.txt
     #   cookiecutter
-build==1.2.2.post1
+build==1.3.0
     # via -r requirements/test.in
-certifi==2025.1.31
+certifi==2026.1.4
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.17.1
-    # via cryptography
 chardet==5.2.0
     # via
     #   -r requirements/base.txt
     #   binaryornot
-charset-normalizer==3.4.1
+charset-normalizer==3.4.4
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.8
+click==8.3.1
     # via
     #   -r requirements/base.txt
     #   click-log
@@ -56,7 +54,7 @@ click-log==0.4.0
     # via
     #   -r requirements/base.txt
     #   edx-lint
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via
     #   -r requirements/base.txt
     #   edx-lint
@@ -64,15 +62,13 @@ cookiecutter==2.6.0
     # via
     #   -r requirements/base.txt
     #   pytest-cookies
-cryptography==44.0.2
-    # via secretstorage
-dill==0.3.9
+dill==0.4.0
     # via
     #   -r requirements/base.txt
     #   pylint
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
-django==4.2.20
+django==5.2.9
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.in
@@ -95,46 +91,42 @@ edx-lint==5.6.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
-filelock==3.18.0
+filelock==3.20.2
     # via virtualenv
 id==1.5.0
     # via twine
-idna==3.10
+idna==3.11
     # via
     #   -r requirements/base.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via pytest
-isort==6.0.1
+isort==7.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.0.1
+jaraco-context==6.0.2
     # via keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.4.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   cookiecutter
     #   sphinx
-keyring==25.6.0
+keyring==25.7.0
     # via twine
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via
     #   -r requirements/base.txt
     #   rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -146,48 +138,43 @@ mdurl==0.1.2
     # via
     #   -r requirements/base.txt
     #   markdown-it-py
-more-itertools==10.6.0
+more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.2.21
+nh3==0.3.2
     # via readme-renderer
-packaging==24.2
+packaging==25.0
     # via
     #   build
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
     #   twine
-pbr==6.1.1
-    # via
-    #   -r requirements/base.txt
-    #   stevedore
-platformdirs==4.3.7
+platformdirs==4.5.1
     # via
     #   -r requirements/base.txt
     #   pylint
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via -r requirements/test.in
-pycparser==2.22
-    # via cffi
 pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
 pydocstyle==6.3.0
     # via -r requirements/test.in
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   -r requirements/base.txt
     #   accessible-pygments
     #   doc8
     #   pydata-sphinx-theme
+    #   pytest
     #   readme-renderer
     #   rich
     #   sphinx
-pylint==3.3.6
+pylint==4.0.4
     # via
     #   -r requirements/base.txt
     #   edx-lint
@@ -198,18 +185,18 @@ pylint-celery==0.3
     # via
     #   -r requirements/base.txt
     #   edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via
     #   -r requirements/base.txt
     #   edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   -r requirements/base.txt
     #   pylint-celery
     #   pylint-django
 pyproject-hooks==1.2.0
     # via build
-pytest==8.3.5
+pytest==9.0.2
     # via pytest-cookies
 pytest-cookies==0.7.0
     # via -r requirements/test.in
@@ -222,14 +209,14 @@ python-slugify==8.0.4
     #   -r requirements/base.txt
     #   code-annotations
     #   cookiecutter
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   -r requirements/base.txt
     #   code-annotations
     #   cookiecutter
 readme-renderer==44.0
     # via twine
-requests==2.32.3
+requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   cookiecutter
@@ -239,19 +226,21 @@ requests==2.32.3
     #   twine
 requests-toolbelt==1.0.0
     # via twine
-restructuredtext-lint==1.4.0
+restructuredtext-lint==2.0.2
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==14.0.0
+rich==14.2.0
     # via
     #   -r requirements/base.txt
     #   cookiecutter
     #   twine
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
+    # via
+    #   roman-numerals-py
+    #   sphinx
+roman-numerals-py==4.1.0
     # via sphinx
-secretstorage==3.3.3
-    # via keyring
 sh==2.2.2
     # via -r requirements/test.in
 six==1.17.0
@@ -259,11 +248,11 @@ six==1.17.0
     #   -r requirements/base.txt
     #   edx-lint
     #   python-dateutil
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via
     #   pydocstyle
     #   sphinx
-soupsieve==2.6
+soupsieve==2.8.1
     # via beautifulsoup4
 sphinx==8.2.3
     # via
@@ -290,9 +279,9 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-stevedore==5.4.1
+stevedore==5.6.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -301,31 +290,24 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via
     #   -r requirements/base.txt
     #   pylint
-twine==6.1.0
+twine==6.2.0
     # via -r requirements/test.in
-types-python-dateutil==2.9.0.20241206
-    # via
-    #   -r requirements/base.txt
-    #   arrow
-typing-extensions==4.13.0
+typing-extensions==4.15.0
     # via
     #   beautifulsoup4
     #   pydata-sphinx-theme
-urllib3==2.2.3
+tzdata==2025.3
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/base.txt
+    #   arrow
+urllib3==2.6.2
+    # via
     #   -r requirements/base.txt
     #   requests
     #   twine
-virtualenv==20.29.3
+virtualenv==20.35.4
     # via -r requirements/test.in
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==78.1.0
-    # via
-    #   -r requirements/base.txt
-    #   pbr


### PR DESCRIPTION
## Description
- `Ubuntu:focal` no longer provides `python 3.12-dev` binaries which is causing test failures in CI when building image using the Dockerfile
- Updated from `ubuntu:focal` to `ubuntu:jammy` since Ubuntu-Jammy still has maintainence support till June 2027.